### PR TITLE
perf: reduce JVM thread count from 50 to 16 (#84)

### DIFF
--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -23,6 +23,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: BPL_JVM_THREAD_COUNT
+              value: "16"
           resources:
             requests:
               memory: 300Mi

--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -29,7 +29,7 @@ spec:
             requests:
               memory: 300Mi
             limits:
-              memory: 550Mi
+              memory: 600Mi
       serviceAccountName: glasskube-operator
       securityContext:
         runAsNonRoot: true

--- a/operator/build.gradle.kts
+++ b/operator/build.gradle.kts
@@ -55,9 +55,18 @@ tasks.test {
     useJUnitPlatform()
 }
 
+// https://docs.spring.io/spring-boot/docs/current/gradle-plugin/reference/htmlsingle/
 tasks.named<BootBuildImage>("bootBuildImage") {
     imageName.set("glasskube/operator")
     tags.add("glasskube/operator:$version")
+    builder.set("paketobuildpacks/builder-jammy-base") // https://paketo.io/docs/reference/builders-reference/
+    runImage.set("paketobuildpacks/run-jammy-base")
+    environment.set(
+        environment.get() + mapOf(
+            "BP_JVM_VERSION" to "17",
+            "BP_SPRING_CLOUD_BINDINGS_DISABLED" to "true"
+        )
+    )
     docker {
         publishRegistry {
             username.set(System.getenv("DOCKERHUB_USERNAME"))


### PR DESCRIPTION
resolves #84 

[Spring Boot Docker](https://spring.io/guides/topicals/spring-boot-docker/) uses [Paketo](https://paketo.io/docs/howto/java/) to build java images. Per default during startup paketo configures dynamic memory limits - which are quite high.

There is a [proposal for a low profile mode in the calculator](https://github.com/paketo-buildpacks/rfcs/blob/main/text/java/0007-low-profile-memory-calc.md).

I reduced the default thread count from [50](https://github.com/paketo-buildpacks/spring-boot/blob/0f0ad7752e3c10ba4c94b98670577763b9e11f82/boot/web_application_type.go#L74). As 16 threads should be more than enough for our use case.

More information can be cound here: https://paketo.io/docs/reference/java-reference/#non-heap