### PR TITLE
Update mariadb-operator refs to its GitHub organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The `deploy.sh` script will automatically install following dependencies:
 - cert-manager [`cert-manager/cert-manager`](https://github.com/cert-manager/cert-manager)
 - Prometheus, Grafana & Alert
   Manager [`prometheus-community/kube-prometheus-stack`](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/README.md)
-- mariadb-operator [`mmontes11/mariadb-operator`](https://github.com/mmontes11/mariadb-operator)
+- mariadb-operator [`mariadb-operator/mariadb-operator`](https://github.com/mariadb-operator/mariadb-operator)
 - CloudNativePG [`cloudnative-pg/cloudnative-pg`](https://github.com/cloudnative-pg/cloudnative-pg)
 - MinIO [`minio/minio`](https://github.com/minio/minio/tree/master/helm/minio)
 
@@ -131,7 +131,7 @@ spec:
 
 [`Matomo`](https://github.com/matomo-org/matomo) is an Open-Source Web Analytics Tool written in `PHP` and stores data
 in `MySQL` database. The Glasskube Operator will automatically perform Upgrades and manages the database.
-Make sure you also have the [`mariadb-operator`](https://github.com/mmontes11/mariadb-operator) installed.
+Make sure you also have the [`mariadb-operator`](https://github.com/mariadb-operator/mariadb-operator) installed.
 After applying the custom resource Matomo will be reachable via an ingress at the configured host.
 
 ### Odoo Kubernetes Operator

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -183,7 +183,7 @@ fi
 
 helm repo add jetstack https://charts.jetstack.io
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo add mariadb-operator https://mmontes11.github.io/mariadb-operator
+helm repo add mariadb-operator https://mariadb-operator.github.io/mariadb-operator
 helm repo add cnpg https://cloudnative-pg.github.io/charts
 helm repo add minio https://charts.min.io/
 helm repo update

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -183,7 +183,7 @@ fi
 
 helm repo add jetstack https://charts.jetstack.io
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo add mariadb-operator https://mariadb-operator.github.io/mariadb-operator
+helm repo add mariadb-operator https://mariadb-operator.github.io/mariadb-operator --force-update
 helm repo add cnpg https://cloudnative-pg.github.io/charts
 helm repo add minio https://charts.min.io/
 helm repo update


### PR DESCRIPTION
Hey there! `mariadb-operator` maintainer here. We have just migrated to a dedicated organization in GitHub and therefore the previous GitHub Pages URLs used in the chart registry will no longer work.

This PR migrates the deployment script and the documentation references to point to the newly created organization:
- https://github.com/mariadb-operator

Also, since DockerHub no longer offers a free tier for organizations, we have also migrated the OCI images to GHCR, see:
- https://github.com/mariadb-operator/mariadb-operator/pkgs/container/mariadb-operator

The [newly released chart](https://artifacthub.io/packages/helm/mariadb-operator/mariadb-operator) defaults to the GHCR images so make sure you update or, alternatively, set an override to your values to point to the GHCR ones.

Thanks for using `mariadb-operator`! ❤️ 