### PR TITLE
feat(Gitea): add support for mailer configuration (#97)

### DIFF
--- a/deploy/crd/giteas.glasskube.eu-v1.yml
+++ b/deploy/crd/giteas.glasskube.eu-v1.yml
@@ -33,6 +33,27 @@ spec:
                 type: boolean
               replicas:
                 type: integer
+              smtp:
+                nullable: true
+                properties:
+                  host:
+                    type: string
+                  port:
+                    type: integer
+                  fromAddress:
+                    type: string
+                  authSecret:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                  tlsEnabled:
+                    type: boolean
+                required:
+                - host
+                - fromAddress
+                - authSecret
+                type: object
             required:
             - host
             type: object

--- a/operator/src/main/kotlin/eu/glasskube/operator/gitea/GiteaSmtp.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/gitea/GiteaSmtp.kt
@@ -1,0 +1,15 @@
+package eu.glasskube.operator.gitea
+
+import io.fabric8.generator.annotation.Required
+import io.fabric8.kubernetes.api.model.LocalObjectReference
+
+data class GiteaSmtp(
+    @field:Required
+    val host: String,
+    val port: Int = 587,
+    @field:Required
+    val fromAddress: String,
+    @field:Required
+    val authSecret: LocalObjectReference,
+    val tlsEnabled: Boolean = true
+)

--- a/operator/src/main/kotlin/eu/glasskube/operator/gitea/GiteaSpec.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/gitea/GiteaSpec.kt
@@ -1,6 +1,7 @@
 package eu.glasskube.operator.gitea
 
 import com.fasterxml.jackson.annotation.JsonPropertyDescription
+import io.fabric8.generator.annotation.Nullable
 import io.fabric8.generator.annotation.Required
 import io.fabric8.kubernetes.api.model.LocalObjectReference
 
@@ -11,5 +12,7 @@ data class GiteaSpec(
     @field:JsonPropertyDescription(value = "Secret containing data of the admin user to create on pod initialization. Expected keys are GITEA_ADMIN_USER, GITEA_ADMIN_EMAIL and GITEA_ADMIN_PASSWORD")
     val adminSecret: LocalObjectReference? = null,
     val registrationEnabled: Boolean = false,
-    val replicas: Int = 1
+    val replicas: Int = 1,
+    @field:Nullable
+    val smtp: GiteaSmtp? = null
 )


### PR DESCRIPTION
This PR adds optional SMTP support for Gitea instances. SMTP configuration looks like this:
```yaml
spec:
  smtp:
    host: smtp.example.com
    port: 465
    fromAddress: gitea@example.com
    authSecret:
      name: smtp-secret
  # additional properties ...
```