### PR TITLE
Common annotations for Ingress & LoadBalancer Services

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.8.10" />
+    <option name="version" value="1.8.21" />
   </component>
 </project>

--- a/operator/src/main/kotlin/eu/glasskube/operator/config/ConfigGenerator.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/config/ConfigGenerator.kt
@@ -12,7 +12,8 @@ import io.javaoperatorsdk.operator.api.reconciler.UpdateControl
     labelSelector = ConfigGenerator.LABEL_SELECTOR,
     generationAwareEventProcessing = false
 )
-class ConfigGenerator(private val kubernetesClient: KubernetesClient, private val configService: ConfigService) : Reconciler<ConfigMap> {
+class ConfigGenerator(private val kubernetesClient: KubernetesClient, private val configService: ConfigService) :
+    Reconciler<ConfigMap> {
 
     init {
         log.info("Glasskube settings are initializing")
@@ -34,6 +35,8 @@ class ConfigGenerator(private val kubernetesClient: KubernetesClient, private va
         return when (it) {
             ConfigKey.cloudProvider -> configService.cloudProvider.name
             ConfigKey.databaseStorageClassName -> detectDatabaseStorageClass()
+            ConfigKey.commonIngressAnnotations,
+            ConfigKey.commonLoadBalancerAnnotations,
             ConfigKey.ingressClassName -> null
         }
     }
@@ -41,7 +44,8 @@ class ConfigGenerator(private val kubernetesClient: KubernetesClient, private va
     private fun detectDatabaseStorageClass(): String {
         val storageClasses = kubernetesClient.storage().v1().storageClasses().list()
         val storageClassNames = storageClasses.items.map { it.metadata.name }
-        val defaultStorageClass = storageClasses.items.find { p -> p.metadata.annotations["storageclass.kubernetes.io/is-default-class"] == "true" }
+        val defaultStorageClass =
+            storageClasses.items.find { p -> p.metadata.annotations["storageclass.kubernetes.io/is-default-class"] == "true" }
         val defaultStorageClassName = defaultStorageClass?.let { defaultStorageClass.metadata.name } ?: "standard"
 
         val awsEncryptedStorageClass = "gp3-encrypted"
@@ -61,6 +65,8 @@ class ConfigGenerator(private val kubernetesClient: KubernetesClient, private va
 
 enum class ConfigKey {
     cloudProvider,
+    commonIngressAnnotations,
+    commonLoadBalancerAnnotations,
     databaseStorageClassName,
     ingressClassName
 }

--- a/operator/src/main/kotlin/eu/glasskube/operator/config/LabelSubstitutionService.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/config/LabelSubstitutionService.kt
@@ -1,0 +1,22 @@
+package eu.glasskube.operator.config
+
+import io.fabric8.kubernetes.api.model.HasMetadata
+import org.springframework.stereotype.Service
+
+@Service
+class LabelSubstitutionService {
+    fun substituteVariables(value: Map<String, String>, primary: HasMetadata): Map<String, String> =
+        value.map { (key, value) -> key to value.substituteVariables(primary) }.toMap()
+
+    private fun String.substituteVariables(primary: HasMetadata): String =
+        PRIMARY_SUBSTITUTIONS.entries.fold(this) { value, (search, replace) ->
+            value.replace(search, replace(primary))
+        }
+
+    companion object {
+        private val PRIMARY_SUBSTITUTIONS: Map<String, HasMetadata.() -> String> = mapOf(
+            "\${primary.metadata.name}" to { metadata.name },
+            "\${primary.metadata.namespace}" to { metadata.namespace }
+        )
+    }
+}

--- a/operator/src/main/kotlin/eu/glasskube/operator/generic/dependent/DependentIngress.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/generic/dependent/DependentIngress.kt
@@ -17,11 +17,12 @@ abstract class DependentIngress<T : HasMetadata>(private val configService: Conf
             else -> configService.ingressClassName
         }
 
-    protected val defaultAnnotations: Map<String, String>
-        get() = when (configService.cloudProvider) {
-            CloudProvider.aws -> awsDefaultAnnotations
-            else -> certManagerDefaultAnnotations
-        }
+    protected fun getDefaultAnnotations(primary: T): Map<String, String> =
+        configService.getCommonIngressAnnotations(primary) +
+            when (configService.cloudProvider) {
+                CloudProvider.aws -> awsDefaultAnnotations
+                else -> certManagerDefaultAnnotations
+            }
 
     private val awsDefaultAnnotations
         get() = mapOf(

--- a/operator/src/main/kotlin/eu/glasskube/operator/generic/dependent/DependentIngress.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/generic/dependent/DependentIngress.kt
@@ -6,10 +6,9 @@ import io.fabric8.kubernetes.api.model.GenericKubernetesResource
 import io.fabric8.kubernetes.api.model.HasMetadata
 import io.fabric8.kubernetes.api.model.networking.v1.Ingress
 import io.fabric8.kubernetes.client.dsl.base.ResourceDefinitionContext
-import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUDKubernetesDependentResource
 
 abstract class DependentIngress<T : HasMetadata>(private val configService: ConfigService) :
-    CRUDKubernetesDependentResource<Ingress, T>(Ingress::class.java) {
+    UpdatableAnnotationsCRUDKubernetesDependentResource<Ingress, T>(Ingress::class.java) {
 
     protected val defaultIngressClassName: String?
         get() = when (configService.cloudProvider) {

--- a/operator/src/main/kotlin/eu/glasskube/operator/generic/dependent/UpdatableAnnotationsCRUDKubernetesDependentResource.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/generic/dependent/UpdatableAnnotationsCRUDKubernetesDependentResource.kt
@@ -1,0 +1,28 @@
+package eu.glasskube.operator.generic.dependent
+
+import io.fabric8.kubernetes.api.model.HasMetadata
+import io.javaoperatorsdk.operator.api.reconciler.Context
+import io.javaoperatorsdk.operator.processing.dependent.Matcher
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUDKubernetesDependentResource
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.GenericKubernetesResourceMatcher
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.ResourceUpdatePreProcessor
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.processors.GenericResourceUpdatePreProcessor
+
+/**
+ * This class of dependent resource is identical to CRUDKubernetesDependentResource, except:
+ * - metadata is considered during matching and
+ * - when a resource is updated, the annotations of the desired resource are applied.
+ */
+abstract class UpdatableAnnotationsCRUDKubernetesDependentResource<R : HasMetadata, P : HasMetadata>(resourceType: Class<R>) :
+    CRUDKubernetesDependentResource<R, P>(resourceType),
+    Matcher<R, P>,
+    ResourceUpdatePreProcessor<R> {
+    private val processorDelegate = GenericResourceUpdatePreProcessor.processorFor(resourceType)
+
+    override fun match(actualResource: R, primary: P, context: Context<P>): Matcher.Result<R> =
+        GenericKubernetesResourceMatcher.match(this, actualResource, primary, context, true)
+
+    override fun replaceSpecOnActual(actual: R, desired: R, context: Context<*>): R =
+        processorDelegate.replaceSpecOnActual(actual, desired, context)
+            .apply { metadata.annotations = desired.metadata.annotations }
+}

--- a/operator/src/main/kotlin/eu/glasskube/operator/gitea/dependent/GiteaIngress.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/gitea/dependent/GiteaIngress.kt
@@ -26,7 +26,7 @@ class GiteaIngress(configService: ConfigService) : DependentIngress<Gitea>(confi
             name = primary.genericResourceName
             namespace = primary.metadata.namespace
             labels = primary.resourceLabels
-            annotations = defaultAnnotations + ("nginx.ingress.kubernetes.io/proxy-body-size" to "256m")
+            annotations = getDefaultAnnotations(primary) + ("nginx.ingress.kubernetes.io/proxy-body-size" to "256m")
         }
         spec {
             ingressClassName = defaultIngressClassName

--- a/operator/src/main/kotlin/eu/glasskube/operator/gitea/dependent/GiteaSSHService.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/gitea/dependent/GiteaSSHService.kt
@@ -5,6 +5,7 @@ import eu.glasskube.kubernetes.api.model.service
 import eu.glasskube.kubernetes.api.model.servicePort
 import eu.glasskube.kubernetes.api.model.spec
 import eu.glasskube.operator.config.ConfigService
+import eu.glasskube.operator.generic.dependent.UpdatableAnnotationsCRUDKubernetesDependentResource
 import eu.glasskube.operator.gitea.Gitea
 import eu.glasskube.operator.gitea.GiteaReconciler
 import eu.glasskube.operator.gitea.resourceLabelSelector
@@ -14,7 +15,6 @@ import io.fabric8.kubernetes.api.model.IntOrString
 import io.fabric8.kubernetes.api.model.Service
 import io.javaoperatorsdk.operator.api.reconciler.Context
 import io.javaoperatorsdk.operator.api.reconciler.ResourceIDMatcherDiscriminator
-import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUDKubernetesDependentResource
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 import io.javaoperatorsdk.operator.processing.event.ResourceID
 
@@ -23,7 +23,7 @@ import io.javaoperatorsdk.operator.processing.event.ResourceID
     resourceDiscriminator = GiteaSSHService.Discriminator::class
 )
 class GiteaSSHService(private val configService: ConfigService) :
-    CRUDKubernetesDependentResource<Service, Gitea>(Service::class.java) {
+    UpdatableAnnotationsCRUDKubernetesDependentResource<Service, Gitea>(Service::class.java) {
     internal class Discriminator : ResourceIDMatcherDiscriminator<Service, Gitea>({ ResourceID(it.sshServiceName) })
 
     override fun desired(primary: Gitea, context: Context<Gitea>) = service {

--- a/operator/src/main/kotlin/eu/glasskube/operator/matomo/dependent/MatomoIngress.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/matomo/dependent/MatomoIngress.kt
@@ -27,7 +27,7 @@ class MatomoIngress(configService: ConfigService) : DependentIngress<Matomo>(con
             name = primary.ingressName
             namespace = primary.metadata.namespace
             labels = primary.resourceLabels
-            annotations = defaultAnnotations
+            annotations = getDefaultAnnotations(primary)
         }
         spec {
             ingressClassName = defaultIngressClassName

--- a/operator/src/main/kotlin/eu/glasskube/operator/minio/MinioBucketReconciler.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/minio/MinioBucketReconciler.kt
@@ -73,7 +73,7 @@ class MinioBucketReconciler(
 
     override fun cleanup(resource: MinioBucket, context: Context<MinioBucket>): DeleteControl {
         with(resource) {
-            when (val username = resource.status.username) {
+            when (val username = resource.status?.username) {
                 null -> log.warn("can not delete user because username is null")
                 else -> deleteBucketUser(username)
             }

--- a/operator/src/main/kotlin/eu/glasskube/operator/odoo/dependent/OdooIngress.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/odoo/dependent/OdooIngress.kt
@@ -26,7 +26,7 @@ class OdooIngress(configService: ConfigService) : DependentIngress<Odoo>(configS
             name = primary.ingressName
             namespace = primary.metadata.namespace
             labels = primary.resourceLabels
-            annotations = defaultAnnotations
+            annotations = getDefaultAnnotations(primary)
         }
         spec {
             ingressClassName = defaultIngressClassName


### PR DESCRIPTION
This PR introduces new settings items for defining annotations that should be added to all Ingress and LoadBalancer Service resources managed by this operator. To use this new feature, add the following to the `glasskube-settings` `ConfigMap` in the `glasskube-system` namespace:

```yaml
data:
  # other items...
  commonLoadBalancerAnnotations: |
    hello: world
    foo: bar
  commonIngressAnnotations: (same as above)
```

Limited support for variable substitution is available. The following substitutions are supported: `${primary.metadata.name}`, `${primary.metadata.namespace}`.