### PR TITLE
chore(deps)!: upgrade to latest mariadb-operator

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -105,7 +105,7 @@ function install_helm_charts {
 
   helm upgrade --install mariadb-operator mariadb-operator/mariadb-operator \
     --namespace "$NS_MARIADB" --create-namespace \
-    --version 0.6.1 \
+    --version 0.15.1 \
     "${MARIADB_ARGS[@]}"
 
   helm upgrade --install cnpg cnpg/cloudnative-pg \


### PR DESCRIPTION
BREAKING CHANGE: mariadb-operator does provide an upgrade path due to changed label selectors. If you want to upgrade from a previous version you need remove and reinstall mariadb-operator