### PR TITLE
chore: remove Glasskube reference from LGPL v3.0 license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,3 @@
-Copyright (c) 2023 Glasskube OS GmbH
-
                    GNU LESSER GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 


### PR DESCRIPTION
Revmoved first 2 lines