### PR TITLE
feat(Gitlab): add the possibility to override gitlab omnibus configuration

### DIFF
--- a/deploy/crd/gitlabs.glasskube.eu-v1.yml
+++ b/deploy/crd/gitlabs.glasskube.eu-v1.yml
@@ -88,6 +88,8 @@ spec:
                       x-kubernetes-int-or-string: true
                     type: object
                 type: object
+              omnibusConfigOverride:
+                type: string
             required:
             - host
             type: object

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/gitlab/GitlabSpec.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/gitlab/GitlabSpec.kt
@@ -19,5 +19,6 @@ data class GitlabSpec(
         null,
         mapOf("memory" to Quantity("3", "Gi")),
         mapOf("cpu" to Quantity("200", "m"), "memory" to Quantity("2", "Gi"))
-    )
+    ),
+    val omnibusConfigOverride: String?
 )

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/gitlab/dependent/GitlabConfigMap.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/gitlab/dependent/GitlabConfigMap.kt
@@ -43,7 +43,7 @@ class GitlabConfigMap : CRUDKubernetesDependentResource<ConfigMap, Gitlab>(Confi
         get() = mapOf(
             "GITLAB_HOST" to "http://${spec.host}",
             "DB_HOST" to postgresHostName,
-            "GITLAB_OMNIBUS_CONFIG" to gitlabOmnibusConfig
+            "GITLAB_OMNIBUS_CONFIG" to (spec.omnibusConfigOverride ?: gitlabOmnibusConfig)
         )
 
     private val Gitlab.sshData: Map<String, String>


### PR DESCRIPTION
Specific configurations of Gitlab can only be configured in the  `[gitlab.rb](https://github.com/glasskube/operator/blob/main/operator/src/main/resources/eu/glasskube/operator/apps/gitlab/dependent/gitlab.rb)` file. For some deployments it can make sense to configure a dedicated omnibus config file which also should be based on top of the base file.