### PR TITLE
feat: Enable Gardener ingress annotations for dns (#250)

### DIFF
--- a/operator/src/main/kotlin/eu/glasskube/operator/config/ConfigGenerator.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/config/ConfigGenerator.kt
@@ -74,6 +74,7 @@ enum class ConfigKey {
 enum class CloudProvider {
     aws,
     hcloud,
+    gardener,
     generic,
 
     @Deprecated("please use `generic` instead")

--- a/operator/src/main/kotlin/eu/glasskube/operator/config/ConfigService.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/config/ConfigService.kt
@@ -58,12 +58,14 @@ class ConfigService(
 
     private val dynamicCloudProvider
         get() = when {
+            kubernetesClient.configMaps().inNamespace("kube-system").withName("shoot-info").get()?.data?.get("extensions")?.contains("shoot-dns-service") == true ->
+                CloudProvider.gardener
+
             kubernetesClient.nodes().withLabel("eks.amazonaws.com/nodegroup").list().items.isNotEmpty() ->
                 CloudProvider.aws
 
             kubernetesClient.nodes().withLabel("csi.hetzner.cloud/location").list().items.isNotEmpty() ->
                 CloudProvider.hcloud
-
             else ->
                 CloudProvider.generic
         }

--- a/operator/src/main/kotlin/eu/glasskube/operator/generic/dependent/DependentIngress.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/generic/dependent/DependentIngress.kt
@@ -21,6 +21,7 @@ abstract class DependentIngress<T : HasMetadata>(private val configService: Conf
         get() = configService.getCommonIngressAnnotations(this) +
             when (configService.cloudProvider) {
                 CloudProvider.aws -> awsDefaultAnnotations
+                CloudProvider.gardener -> gardenerDefaultAnnotations
                 else -> certManagerDefaultAnnotations
             }
 
@@ -31,6 +32,13 @@ abstract class DependentIngress<T : HasMetadata>(private val configService: Conf
             "alb.ingress.kubernetes.io/target-type" to "ip",
             "alb.ingress.kubernetes.io/ssl-redirect" to "443",
             "alb.ingress.kubernetes.io/group.name" to "glasskube"
+        )
+
+    private val gardenerDefaultAnnotations
+        get() = mapOf(
+            "dns.gardener.cloud/class" to "garden",
+            "dns.gardener.cloud/dnsnames" to "*",
+            "dns.gardener.cloud/ttl" to "600"
         )
 
     private val certManagerDefaultAnnotations


### PR DESCRIPTION
This PR enables the use of Gardener ingress for automatic creation of Dnsentries, when the operator is run on a Gardener-based Kubernetes cluster.