### PR TITLE
docs: add search page to footer

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -62,6 +62,7 @@ const config = {
             items: [
               {label: 'Getting started', to: 'getting-started/install'},
               {label: 'CRD Reference', to: 'crd-reference'},
+              {label: 'Search', to: 'search'},
             ],
           },
           {


### PR DESCRIPTION
This links make sure that the search page which is referenced in the sitemap is no orphan page.