### PR TITLE
fix: add deletion permission to cluster role

### DIFF
--- a/charts/glasskube-operator/templates/cluster-role.yaml
+++ b/charts/glasskube-operator/templates/cluster-role.yaml
@@ -39,7 +39,7 @@ rules:
       - update
       - watch
   - apiGroups:
-      - ""
+      - ''
     resources:
       - services
       - secrets
@@ -54,7 +54,20 @@ rules:
       - update
       - watch
   - apiGroups:
-      - ""
+      - 'apps'
+    resources:
+      - deployments
+    verbs:
+      - delete
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+      - services
+    verbs:
+      - delete
+  - apiGroups:
+      - ''
     resources:
       - persistentvolumeclaims
     verbs:

--- a/deploy/cluster/cluster-role.yaml
+++ b/deploy/cluster/cluster-role.yaml
@@ -39,7 +39,7 @@ rules:
       - update
       - watch
   - apiGroups:
-      - ""
+      - ''
     resources:
       - services
       - secrets
@@ -54,7 +54,20 @@ rules:
       - update
       - watch
   - apiGroups:
-      - ""
+      - 'apps'
+    resources:
+      - deployments
+    verbs:
+      - delete
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+      - services
+    verbs:
+      - delete
+  - apiGroups:
+      - ''
     resources:
       - persistentvolumeclaims
     verbs:


### PR DESCRIPTION
Additional permissions are needed to delete deployments, services and configmaps in order to perform the plane upgrade of #384 