### PR TITLE
fix(Glitchtip): avoid http 502 from ingress (#400)

### DIFF
--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/glitchtip/GlitchtipSpec.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/glitchtip/GlitchtipSpec.kt
@@ -23,7 +23,7 @@ data class GlitchtipSpec(
         mapOf("memory" to Quantity("700", "Mi"))
     ),
     @field:Pattern(SEMVER)
-    val version: String = "3.3.1",
+    val version: String = "3.4.0",
     @field:Nullable
     override val database: PostgresDatabaseSpec = PostgresDatabaseSpec()
 ) : HasDatabaseSpec<PostgresDatabaseSpec>

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/glitchtip/dependent/GlitchtipIngress.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/glitchtip/dependent/GlitchtipIngress.kt
@@ -28,7 +28,10 @@ class GlitchtipIngress(configService: ConfigService) : DependentIngress<Glitchti
             labels(primary.resourceLabels)
             annotations(
                 getDefaultAnnotations(primary, context) +
-                    ("nginx.ingress.kubernetes.io/proxy-body-size" to "256m")
+                    mapOf(
+                        "nginx.ingress.kubernetes.io/proxy-body-size" to "256m",
+                        "nginx.ingress.kubernetes.io/proxy-next-upstream-tries" to "10"
+                    )
             )
         }
         spec {


### PR DESCRIPTION
## Pull Request Template

### Proposed Changes

Let the ingress try multiple times if connection is refused from upstream service. 

### Related Issues

- Closes #400
