### PR TITLE
fix(Gitea): change secure mailer protocol to smtps unless port is 587

### DIFF
--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/gitea/dependent/GiteaIniConfigMap.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/gitea/dependent/GiteaIniConfigMap.kt
@@ -71,7 +71,14 @@ class GiteaIniConfigMap : CRUDKubernetesDependentResource<ConfigMap, Gitea>(Conf
                     "GITEA__service__ENABLE_NOTIFY_MAIL" to "true",
                     "GITEA__mailer__ENABLED" to "true",
                     "GITEA__mailer__FROM" to smtp.fromAddress,
-                    "GITEA__mailer__PROTOCOL" to if (smtp.tlsEnabled) "smtp+starttls" else "smtp",
+                    "GITEA__mailer__PROTOCOL" to when (smtp.tlsEnabled) {
+                        true -> when (smtp.port) {
+                            587 -> "smtp+starttls"
+                            else -> "smtps"
+                        }
+
+                        false -> "smtp"
+                    },
                     "GITEA__mailer__SMTP_ADDR" to smtp.host,
                     "GITEA__mailer__SMTP_PORT" to smtp.port.toString(),
                     "GITEA__mailer__USER" to authSecret.data.getValue("username").decodeBase64(),


### PR DESCRIPTION
https://github.com/glasskube/operator/pull/387 implicitly introduced a change in the mailer protocol used if `tlsEnabled` is set to `true`. Previously, Gitea used to select "smtps" by default but now it was changed to "smtp-starttls".

With this change, the protocol is changed back to "smtps", unless the SMTP port is set to 587, in which case it is set to "smtp-starttls".