### PR TITLE
docs: add docusaurus matomo plugin

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -13,6 +13,7 @@ const config = {
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   i18n: {defaultLocale: 'en', locales: ['en']},
+  plugins: ['docusaurus-plugin-matomo'],
   presets: [
     [
       'classic',
@@ -92,6 +93,12 @@ const config = {
       prism: {
         theme: themes.github,
         darkTheme: themes.dracula
+      },
+      matomo: {
+        matomoUrl: 'https://a.glasskube.eu/',
+        siteId: '2',
+        phpLoader: 'matomo.php',
+        jsLoader: 'matomo.js',
       },
     }),
 };

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -13,6 +13,7 @@
         "@easyops-cn/docusaurus-search-local": "^0.37.0",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
+        "docusaurus-plugin-matomo": "0.0.6",
         "prism-react-renderer": "^2.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -5942,6 +5943,17 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/docusaurus-plugin-matomo": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/docusaurus-plugin-matomo/-/docusaurus-plugin-matomo-0.0.6.tgz",
+      "integrity": "sha512-zAhUz3eMaW2tUJsvV5guOMwb554swoVEeI55BZA10LVk3+PyfWYpBl2FEHITe0ofA8/vG6BTuTzGNSWxW70NwA==",
+      "engines": {
+        "node": ">=12.13.0"
+      },
+      "peerDependencies": {
+        "@docusaurus/core": "^2.0.0-alpha.56"
       }
     },
     "node_modules/dom-converter": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -17,12 +17,18 @@
     "@easyops-cn/docusaurus-search-local": "^0.37.0",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
+    "docusaurus-plugin-matomo": "0.0.6",
     "prism-react-renderer": "^2.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.0.0"
+  },
+  "overrides": {
+    "docusaurus-plugin-matomo": {
+      "@docusaurus/core": "3.0.0"
+    }
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
I added the plugin as a gz file until the upstream pr is merged.

Link to upstream PR: https://github.com/karser/docusaurus-plugin-matomo/pull/6



