### PR TITLE
chore(Matomo): update mariadb crds to support v0.22.0

### DIFF
--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/matomo/dependent/MatomoMariaDB.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/matomo/dependent/MatomoMariaDB.kt
@@ -19,7 +19,6 @@ import eu.glasskube.operator.config.ConfigService
 import eu.glasskube.operator.generic.condition.MariaDBReadyCondition
 import eu.glasskube.operator.infra.mariadb.Exporter
 import eu.glasskube.operator.infra.mariadb.MariaDB
-import eu.glasskube.operator.infra.mariadb.MariaDBImage
 import eu.glasskube.operator.infra.mariadb.MariaDBResources
 import eu.glasskube.operator.infra.mariadb.MariaDBResourcesRequest
 import eu.glasskube.operator.infra.mariadb.MariaDBSpec
@@ -60,7 +59,7 @@ class MatomoMariaDB(private val configService: ConfigService) :
         }
         spec = MariaDBSpec(
             rootPasswordSecretKeyRef = secretKeySelector(primary.databaseSecretName, ROOT_DATABASE_PASSWORD),
-            image = MariaDBImage("mariadb", "10.7.4", "IfNotPresent"),
+            image = "mariadb:10.7.4",
             database = primary.databaseName,
             username = primary.databaseUser,
             passwordSecretKeyRef = secretKeySelector(primary.databaseSecretName, MATOMO_DATABASE_PASSWORD),
@@ -75,7 +74,7 @@ class MatomoMariaDB(private val configService: ConfigService) :
             ),
             metrics = Metrics(
                 exporter = Exporter(
-                    image = MariaDBImage("prom/mysqld-exporter", "v0.14.0", "IfNotPresent")
+                    image = "prom/mysqld-exporter:v0.14.0"
                 ),
                 serviceMonitor = ServiceMonitor(
                     prometheusRelease = "kube-prometheus-stack"

--- a/operator/src/main/kotlin/eu/glasskube/operator/infra/mariadb/Exporter.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/infra/mariadb/Exporter.kt
@@ -1,6 +1,7 @@
 package eu.glasskube.operator.infra.mariadb
 
 data class Exporter(
-    val image: MariaDBImage,
+    val image: String,
+    var imagePullPolicy: String = "IfNotPresent",
     val resources: MariaDBResources? = null
 )

--- a/operator/src/main/kotlin/eu/glasskube/operator/infra/mariadb/MariaDB.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/infra/mariadb/MariaDB.kt
@@ -11,12 +11,6 @@ import io.fabric8.kubernetes.client.CustomResource
 import io.fabric8.kubernetes.model.annotation.Group
 import io.fabric8.kubernetes.model.annotation.Version
 
-data class MariaDBImage(
-    var repository: String,
-    var tag: String,
-    var pullPolicy: String? = null
-)
-
 data class MariaDBResourcesRequest(
     val storage: String? = null,
     val cpu: String? = null,
@@ -36,7 +30,8 @@ data class MariaDBVolumeClaimTemplate(
 
 data class MariaDBSpec(
     var rootPasswordSecretKeyRef: SecretKeySelector,
-    var image: MariaDBImage,
+    var image: String,
+    var imagePullPolicy: String = "IfNotPresent",
     var database: String?,
     var username: String?,
     var passwordSecretKeyRef: SecretKeySelector?,


### PR DESCRIPTION
### Upgrade notes
* Before the update:
  * Scale the glasskube operator deployment to 0 if it is running
  * Delete all MariaDBs created by the glasskube operator
    This is needed because k8s does not remove the `spec.image` property (that received an incompatible change in this update) but sets it to `{}` (which is no longer valid with the new crd version). If this step is skipped, neither the glasskube operator, nor the mariadb operator will be able to deserialize the objects and they have to be force deleted.
* See https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/UPGRADE_v0.0.21.md for general upgrade procedure
* After the update: Scale the glasskube operator deployment back to 1