### PR TITLE
chore(Nextcloud): change button label to be similar to other log in buttons

### DIFF
--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/nextcloud/dependent/NextcloudConfigMap.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/nextcloud/dependent/NextcloudConfigMap.kt
@@ -66,7 +66,7 @@ class NextcloudConfigMap : CRUDKubernetesDependentResource<ConfigMap, Nextcloud>
                         arrayOf(
                             "oidc_login_provider_url" to it.issuerUrl,
                             "oidc_login_logout_url" to primary.spec.host,
-                            "oidc_login_button_text" to "Login with " + it.name,
+                            "oidc_login_button_text" to "Log in with " + it.name,
                             "oidc_login_disable_registration" to false,
                             "oidc_login_scope" to "openid profile email",
                             "oidc_login_attributes" to mapOf(


### PR DESCRIPTION
We preix "Login" but should rather prefix "Log in" as all other buttons are called "Log in":

![image](https://github.com/glasskube/operator/assets/3041752/75ee333a-4613-4476-b958-a5446804e7b6)
