### PR TITLE
fix: typo in GlitchTipVeleroSecret

### DIFF
--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/glitchtip/dependent/GlitchtipVeleroSecret.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/glitchtip/dependent/GlitchtipVeleroSecret.kt
@@ -1,6 +1,5 @@
 package eu.glasskube.operator.apps.glitchtip.dependent
 
-import eu.glasskube.operator.apps.gitea.Gitea
 import eu.glasskube.operator.apps.glitchtip.Glitchtip
 import eu.glasskube.operator.generic.dependent.backups.BackupSpecNotNullCondition
 import eu.glasskube.operator.generic.dependent.backups.DependentVeleroSecret
@@ -9,6 +8,6 @@ import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDep
 
 @KubernetesDependent(resourceDiscriminator = GlitchtipVeleroSecret.Discriminator::class)
 class GlitchtipVeleroSecret : DependentVeleroSecret<Glitchtip>() {
-    internal class ReconcilePrecondition : BackupSpecNotNullCondition<Secret, Gitea>()
+    internal class ReconcilePrecondition : BackupSpecNotNullCondition<Secret, Glitchtip>()
     internal class Discriminator : DependentVeleroSecret.Discriminator<Glitchtip>()
 }


### PR DESCRIPTION
That commit fixes an infamous error that that the opartor was not able to watch the v1/secrets endpoint
