### PR TITLE
chore: additional migrations after JOSDK update

### DIFF
--- a/charts/glasskube-operator/templates/giteas.glasskube.eu-v1.yml
+++ b/charts/glasskube-operator/templates/giteas.glasskube.eu-v1.yml
@@ -17,12 +17,6 @@ spec:
         properties:
           spec:
             properties:
-              host:
-                type: string
-              sshEnabled:
-                type: boolean
-              sshHost:
-                type: string
               adminSecret:
                 description: "Secret containing data of the admin user to create on\
                   \ pod initialization. Expected keys are GITEA_ADMIN_USER, GITEA_ADMIN_EMAIL\
@@ -31,31 +25,122 @@ spec:
                   name:
                     type: string
                 type: object
+              backups:
+                properties:
+                  s3:
+                    properties:
+                      accessKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      bucket:
+                        type: string
+                      hostname:
+                        nullable: true
+                        type: string
+                      port:
+                        nullable: true
+                        type: integer
+                      region:
+                        nullable: true
+                        type: string
+                      secretKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      usePathStyle:
+                        type: boolean
+                      useSsl:
+                        type: boolean
+                    required:
+                    - bucket
+                    - accessKeySecret
+                    - secretKeySecret
+                    type: object
+                  schedule:
+                    type: string
+                  ttl:
+                    type: string
+                required:
+                - s3
+                type: object
+              database:
+                nullable: true
+                properties:
+                  backups:
+                    properties:
+                      retentionPolicy:
+                        type: string
+                      s3:
+                        properties:
+                          accessKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          bucket:
+                            type: string
+                          endpoint:
+                            type: string
+                          regionSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          secretKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                        required:
+                        - bucket
+                        - accessKeySecret
+                        - secretKeySecret
+                        type: object
+                      schedule:
+                        type: string
+                    required:
+                    - s3
+                    type: object
+                  instances:
+                    minimum: 1.0
+                    type: integer
+                  storage:
+                    properties:
+                      size:
+                        type: string
+                      storageClass:
+                        type: string
+                    type: object
+                type: object
+              host:
+                type: string
               registrationEnabled:
                 type: boolean
               replicas:
                 type: integer
-              smtp:
-                nullable: true
-                properties:
-                  host:
-                    type: string
-                  port:
-                    type: integer
-                  fromAddress:
-                    type: string
-                  authSecret:
-                    properties:
-                      name:
-                        type: string
-                    type: object
-                  tlsEnabled:
-                    type: boolean
-                required:
-                - host
-                - fromAddress
-                - authSecret
-                type: object
               resources:
                 properties:
                   claims:
@@ -80,80 +165,44 @@ spec:
                       x-kubernetes-int-or-string: true
                     type: object
                 type: object
+              smtp:
+                nullable: true
+                properties:
+                  authSecret:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                  fromAddress:
+                    type: string
+                  host:
+                    type: string
+                  port:
+                    type: integer
+                  tlsEnabled:
+                    type: boolean
+                required:
+                - host
+                - fromAddress
+                - authSecret
+                type: object
+              sshEnabled:
+                type: boolean
+              sshHost:
+                type: string
               version:
                 pattern: \d+\.\d+\.\d+
                 type: string
-              database:
-                nullable: true
-                properties:
-                  instances:
-                    minimum: 1.0
-                    type: integer
-                  backups:
-                    properties:
-                      schedule:
-                        type: string
-                      retentionPolicy:
-                        type: string
-                      s3:
-                        properties:
-                          endpoint:
-                            type: string
-                          regionSecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          bucket:
-                            type: string
-                          accessKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          secretKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                        required:
-                        - bucket
-                        - accessKeySecret
-                        - secretKeySecret
-                        type: object
-                    required:
-                    - s3
-                    type: object
-                  storage:
-                    properties:
-                      size:
-                        type: string
-                      storageClass:
-                        type: string
-                    type: object
-                type: object
             required:
             - host
             type: object
           status:
             properties:
+              postgresReady:
+                type: boolean
               readyReplicas:
                 type: integer
               redisReady:
-                type: boolean
-              postgresReady:
                 type: boolean
             type: object
         type: object

--- a/charts/glasskube-operator/templates/gitlabrunners.glasskube.eu-v1.yml
+++ b/charts/glasskube-operator/templates/gitlabrunners.glasskube.eu-v1.yml
@@ -17,15 +17,15 @@ spec:
         properties:
           spec:
             properties:
-              token:
-                type: string
+              concurrency:
+                type: integer
               gitlab:
                 properties:
                   name:
                     type: string
                 type: object
-              concurrency:
-                type: integer
+              token:
+                type: string
               version:
                 pattern: \d+\.\d+\.\d+
                 type: string

--- a/charts/glasskube-operator/templates/gitlabs.glasskube.eu-v1.yml
+++ b/charts/glasskube-operator/templates/gitlabs.glasskube.eu-v1.yml
@@ -17,12 +17,118 @@ spec:
         properties:
           spec:
             properties:
+              backups:
+                properties:
+                  s3:
+                    properties:
+                      accessKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      bucket:
+                        type: string
+                      hostname:
+                        nullable: true
+                        type: string
+                      port:
+                        nullable: true
+                        type: integer
+                      region:
+                        nullable: true
+                        type: string
+                      secretKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      usePathStyle:
+                        type: boolean
+                      useSsl:
+                        type: boolean
+                    required:
+                    - bucket
+                    - accessKeySecret
+                    - secretKeySecret
+                    type: object
+                  schedule:
+                    type: string
+                  ttl:
+                    type: string
+                required:
+                - s3
+                type: object
+              database:
+                nullable: true
+                properties:
+                  backups:
+                    properties:
+                      retentionPolicy:
+                        type: string
+                      s3:
+                        properties:
+                          accessKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          bucket:
+                            type: string
+                          endpoint:
+                            type: string
+                          regionSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          secretKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                        required:
+                        - bucket
+                        - accessKeySecret
+                        - secretKeySecret
+                        type: object
+                      schedule:
+                        type: string
+                    required:
+                    - s3
+                    type: object
+                  instances:
+                    minimum: 1.0
+                    type: integer
+                  storage:
+                    properties:
+                      size:
+                        type: string
+                      storageClass:
+                        type: string
+                    type: object
+                type: object
               host:
                 type: string
-              sshHost:
-                type: string
-              sshEnabled:
-                type: boolean
               initialRootPasswordSecret:
                 properties:
                   key:
@@ -32,41 +138,59 @@ spec:
                   optional:
                     type: boolean
                 type: object
-              smtp:
+              omnibusConfigOverride:
+                nullable: true
+                type: string
+              registry:
                 nullable: true
                 properties:
                   host:
                     type: string
-                  port:
-                    type: integer
-                  fromAddress:
-                    type: string
-                  authSecret:
+                  storage:
+                    nullable: true
                     properties:
-                      name:
-                        type: string
+                      s3:
+                        properties:
+                          accessKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          bucket:
+                            type: string
+                          hostname:
+                            type: string
+                          port:
+                            type: integer
+                          region:
+                            type: string
+                          secretKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          usePathStyle:
+                            type: boolean
+                          useSsl:
+                            type: boolean
+                        required:
+                        - bucket
+                        - accessKeySecret
+                        - secretKeySecret
+                        - region
+                        type: object
                     type: object
-                  tlsEnabled:
-                    type: boolean
                 required:
                 - host
-                - fromAddress
-                - authSecret
                 type: object
-              runners:
-                items:
-                  properties:
-                    token:
-                      type: string
-                    concurrency:
-                      type: integer
-                    version:
-                      pattern: \d+\.\d+\.\d+
-                      type: string
-                  required:
-                  - token
-                  type: object
-                type: array
               resources:
                 properties:
                   claims:
@@ -91,132 +215,57 @@ spec:
                       x-kubernetes-int-or-string: true
                     type: object
                 type: object
-              omnibusConfigOverride:
-                nullable: true
-                type: string
-              registry:
+              runners:
+                items:
+                  properties:
+                    concurrency:
+                      type: integer
+                    token:
+                      type: string
+                    version:
+                      pattern: \d+\.\d+\.\d+
+                      type: string
+                  required:
+                  - token
+                  type: object
+                type: array
+              smtp:
                 nullable: true
                 properties:
+                  authSecret:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                  fromAddress:
+                    type: string
                   host:
                     type: string
-                  storage:
-                    nullable: true
-                    properties:
-                      s3:
-                        properties:
-                          bucket:
-                            type: string
-                          accessKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          secretKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          region:
-                            type: string
-                          hostname:
-                            type: string
-                          port:
-                            type: integer
-                          useSsl:
-                            type: boolean
-                          usePathStyle:
-                            type: boolean
-                        required:
-                        - bucket
-                        - accessKeySecret
-                        - secretKeySecret
-                        - region
-                        type: object
-                    type: object
+                  port:
+                    type: integer
+                  tlsEnabled:
+                    type: boolean
                 required:
                 - host
+                - fromAddress
+                - authSecret
                 type: object
+              sshEnabled:
+                type: boolean
+              sshHost:
+                type: string
               version:
                 pattern: \d+\.\d+\.\d+
                 type: string
-              database:
-                nullable: true
-                properties:
-                  instances:
-                    minimum: 1.0
-                    type: integer
-                  backups:
-                    properties:
-                      schedule:
-                        type: string
-                      retentionPolicy:
-                        type: string
-                      s3:
-                        properties:
-                          endpoint:
-                            type: string
-                          regionSecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          bucket:
-                            type: string
-                          accessKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          secretKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                        required:
-                        - bucket
-                        - accessKeySecret
-                        - secretKeySecret
-                        type: object
-                    required:
-                    - s3
-                    type: object
-                  storage:
-                    properties:
-                      size:
-                        type: string
-                      storageClass:
-                        type: string
-                    type: object
-                type: object
             required:
             - host
             type: object
           status:
             properties:
-              readyReplicas:
-                type: integer
               postgresReady:
                 type: boolean
+              readyReplicas:
+                type: integer
               runners:
                 additionalProperties:
                   properties:

--- a/charts/glasskube-operator/templates/glitchtips.glasskube.eu-v1.yml
+++ b/charts/glasskube-operator/templates/glitchtips.glasskube.eu-v1.yml
@@ -17,35 +17,124 @@ spec:
         properties:
           spec:
             properties:
-              host:
-                type: string
-              replicas:
-                type: integer
-              registrationEnabled:
-                type: boolean
-              organizationCreationEnabled:
-                type: boolean
-              smtp:
+              backups:
+                properties:
+                  s3:
+                    properties:
+                      accessKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      bucket:
+                        type: string
+                      hostname:
+                        nullable: true
+                        type: string
+                      port:
+                        nullable: true
+                        type: integer
+                      region:
+                        nullable: true
+                        type: string
+                      secretKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      usePathStyle:
+                        type: boolean
+                      useSsl:
+                        type: boolean
+                    required:
+                    - bucket
+                    - accessKeySecret
+                    - secretKeySecret
+                    type: object
+                  schedule:
+                    type: string
+                  ttl:
+                    type: string
+                required:
+                - s3
+                type: object
+              database:
                 nullable: true
                 properties:
-                  host:
-                    type: string
-                  port:
-                    type: integer
-                  fromAddress:
-                    type: string
-                  authSecret:
+                  backups:
                     properties:
-                      name:
+                      retentionPolicy:
+                        type: string
+                      s3:
+                        properties:
+                          accessKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          bucket:
+                            type: string
+                          endpoint:
+                            type: string
+                          regionSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          secretKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                        required:
+                        - bucket
+                        - accessKeySecret
+                        - secretKeySecret
+                        type: object
+                      schedule:
+                        type: string
+                    required:
+                    - s3
+                    type: object
+                  instances:
+                    minimum: 1.0
+                    type: integer
+                  storage:
+                    properties:
+                      size:
+                        type: string
+                      storageClass:
                         type: string
                     type: object
-                  tlsEnabled:
-                    type: boolean
-                required:
-                - host
-                - fromAddress
-                - authSecret
                 type: object
+              host:
+                type: string
+              organizationCreationEnabled:
+                type: boolean
+              registrationEnabled:
+                type: boolean
+              replicas:
+                type: integer
               resources:
                 properties:
                   claims:
@@ -70,83 +159,43 @@ spec:
                       x-kubernetes-int-or-string: true
                     type: object
                 type: object
+              smtp:
+                nullable: true
+                properties:
+                  authSecret:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                  fromAddress:
+                    type: string
+                  host:
+                    type: string
+                  port:
+                    type: integer
+                  tlsEnabled:
+                    type: boolean
+                required:
+                - host
+                - fromAddress
+                - authSecret
+                type: object
               version:
                 pattern: \d+\.\d+\.\d+
                 type: string
-              database:
-                nullable: true
-                properties:
-                  instances:
-                    minimum: 1.0
-                    type: integer
-                  backups:
-                    properties:
-                      schedule:
-                        type: string
-                      retentionPolicy:
-                        type: string
-                      s3:
-                        properties:
-                          endpoint:
-                            type: string
-                          regionSecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          bucket:
-                            type: string
-                          accessKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          secretKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                        required:
-                        - bucket
-                        - accessKeySecret
-                        - secretKeySecret
-                        type: object
-                    required:
-                    - s3
-                    type: object
-                  storage:
-                    properties:
-                      size:
-                        type: string
-                      storageClass:
-                        type: string
-                    type: object
-                type: object
             required:
             - host
             type: object
           status:
             properties:
+              postgresReady:
+                type: boolean
               readyReplicas:
-                type: integer
-              workerReadyReplicas:
                 type: integer
               redisReady:
                 type: boolean
-              postgresReady:
-                type: boolean
+              workerReadyReplicas:
+                type: integer
             type: object
         type: object
     served: true

--- a/charts/glasskube-operator/templates/keycloaks.glasskube.eu-v1.yml
+++ b/charts/glasskube-operator/templates/keycloaks.glasskube.eu-v1.yml
@@ -17,8 +17,127 @@ spec:
         properties:
           spec:
             properties:
+              backups:
+                properties:
+                  s3:
+                    properties:
+                      accessKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      bucket:
+                        type: string
+                      hostname:
+                        nullable: true
+                        type: string
+                      port:
+                        nullable: true
+                        type: integer
+                      region:
+                        nullable: true
+                        type: string
+                      secretKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      usePathStyle:
+                        type: boolean
+                      useSsl:
+                        type: boolean
+                    required:
+                    - bucket
+                    - accessKeySecret
+                    - secretKeySecret
+                    type: object
+                  schedule:
+                    type: string
+                  ttl:
+                    type: string
+                required:
+                - s3
+                type: object
+              database:
+                nullable: true
+                properties:
+                  backups:
+                    properties:
+                      retentionPolicy:
+                        type: string
+                      s3:
+                        properties:
+                          accessKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          bucket:
+                            type: string
+                          endpoint:
+                            type: string
+                          regionSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          secretKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                        required:
+                        - bucket
+                        - accessKeySecret
+                        - secretKeySecret
+                        type: object
+                      schedule:
+                        type: string
+                    required:
+                    - s3
+                    type: object
+                  instances:
+                    minimum: 1.0
+                    type: integer
+                  storage:
+                    properties:
+                      size:
+                        type: string
+                      storageClass:
+                        type: string
+                    type: object
+                type: object
               host:
                 type: string
+              image:
+                type: string
+              imagePullSecrets:
+                items:
+                  properties:
+                    name:
+                      type: string
+                  type: object
+                type: array
               management:
                 properties:
                   enabled:
@@ -51,76 +170,15 @@ spec:
               version:
                 pattern: \d+\.\d+\.\d+
                 type: string
-              database:
-                nullable: true
-                properties:
-                  instances:
-                    minimum: 1.0
-                    type: integer
-                  backups:
-                    properties:
-                      schedule:
-                        type: string
-                      retentionPolicy:
-                        type: string
-                      s3:
-                        properties:
-                          endpoint:
-                            type: string
-                          regionSecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          bucket:
-                            type: string
-                          accessKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          secretKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                        required:
-                        - bucket
-                        - accessKeySecret
-                        - secretKeySecret
-                        type: object
-                    required:
-                    - s3
-                    type: object
-                  storage:
-                    properties:
-                      size:
-                        type: string
-                      storageClass:
-                        type: string
-                    type: object
-                type: object
             required:
             - host
             type: object
           status:
             properties:
-              readyInstances:
-                type: integer
               postgresReady:
                 type: boolean
+              readyInstances:
+                type: integer
             type: object
         type: object
     served: true

--- a/charts/glasskube-operator/templates/matomos.glasskube.eu-v1.yml
+++ b/charts/glasskube-operator/templates/matomos.glasskube.eu-v1.yml
@@ -17,29 +17,69 @@ spec:
         properties:
           spec:
             properties:
-              host:
-                type: string
-              smtp:
-                nullable: true
+              backups:
                 properties:
-                  host:
-                    type: string
-                  port:
-                    type: integer
-                  fromAddress:
-                    type: string
-                  authSecret:
+                  s3:
                     properties:
-                      name:
+                      accessKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      bucket:
+                        type: string
+                      hostname:
+                        nullable: true
+                        type: string
+                      port:
+                        nullable: true
+                        type: integer
+                      region:
+                        nullable: true
+                        type: string
+                      secretKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      usePathStyle:
+                        type: boolean
+                      useSsl:
+                        type: boolean
+                    required:
+                    - bucket
+                    - accessKeySecret
+                    - secretKeySecret
+                    type: object
+                  schedule:
+                    type: string
+                  ttl:
+                    type: string
+                required:
+                - s3
+                type: object
+              database:
+                properties:
+                  backups:
+                    type: object
+                  storage:
+                    properties:
+                      size:
+                        type: string
+                      storageClass:
                         type: string
                     type: object
-                  tlsEnabled:
-                    type: boolean
-                required:
-                - host
-                - fromAddress
-                - authSecret
                 type: object
+              host:
+                type: string
               resources:
                 properties:
                   claims:
@@ -64,20 +104,29 @@ spec:
                       x-kubernetes-int-or-string: true
                     type: object
                 type: object
+              smtp:
+                nullable: true
+                properties:
+                  authSecret:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                  fromAddress:
+                    type: string
+                  host:
+                    type: string
+                  port:
+                    type: integer
+                  tlsEnabled:
+                    type: boolean
+                required:
+                - host
+                - fromAddress
+                - authSecret
+                type: object
               version:
                 type: string
-              database:
-                properties:
-                  storage:
-                    properties:
-                      size:
-                        type: string
-                      storageClass:
-                        type: string
-                    type: object
-                  backups:
-                    type: object
-                type: object
             type: object
           status:
             properties:

--- a/charts/glasskube-operator/templates/metabases.glasskube.eu-v1.yml
+++ b/charts/glasskube-operator/templates/metabases.glasskube.eu-v1.yml
@@ -17,31 +17,120 @@ spec:
         properties:
           spec:
             properties:
+              backups:
+                properties:
+                  s3:
+                    properties:
+                      accessKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      bucket:
+                        type: string
+                      hostname:
+                        nullable: true
+                        type: string
+                      port:
+                        nullable: true
+                        type: integer
+                      region:
+                        nullable: true
+                        type: string
+                      secretKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      usePathStyle:
+                        type: boolean
+                      useSsl:
+                        type: boolean
+                    required:
+                    - bucket
+                    - accessKeySecret
+                    - secretKeySecret
+                    type: object
+                  schedule:
+                    type: string
+                  ttl:
+                    type: string
+                required:
+                - s3
+                type: object
+              database:
+                nullable: true
+                properties:
+                  backups:
+                    properties:
+                      retentionPolicy:
+                        type: string
+                      s3:
+                        properties:
+                          accessKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          bucket:
+                            type: string
+                          endpoint:
+                            type: string
+                          regionSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          secretKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                        required:
+                        - bucket
+                        - accessKeySecret
+                        - secretKeySecret
+                        type: object
+                      schedule:
+                        type: string
+                    required:
+                    - s3
+                    type: object
+                  instances:
+                    minimum: 1.0
+                    type: integer
+                  storage:
+                    properties:
+                      size:
+                        type: string
+                      storageClass:
+                        type: string
+                    type: object
+                type: object
               host:
                 type: string
               replicas:
                 type: integer
-              smtp:
-                nullable: true
-                properties:
-                  host:
-                    type: string
-                  port:
-                    type: integer
-                  fromAddress:
-                    type: string
-                  authSecret:
-                    properties:
-                      name:
-                        type: string
-                    type: object
-                  tlsEnabled:
-                    type: boolean
-                required:
-                - host
-                - fromAddress
-                - authSecret
-                type: object
               resources:
                 properties:
                   claims:
@@ -66,79 +155,39 @@ spec:
                       x-kubernetes-int-or-string: true
                     type: object
                 type: object
+              smtp:
+                nullable: true
+                properties:
+                  authSecret:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                  fromAddress:
+                    type: string
+                  host:
+                    type: string
+                  port:
+                    type: integer
+                  tlsEnabled:
+                    type: boolean
+                required:
+                - host
+                - fromAddress
+                - authSecret
+                type: object
               version:
                 pattern: \d+\.\d+\.\d+
                 type: string
-              database:
-                nullable: true
-                properties:
-                  instances:
-                    minimum: 1.0
-                    type: integer
-                  backups:
-                    properties:
-                      schedule:
-                        type: string
-                      retentionPolicy:
-                        type: string
-                      s3:
-                        properties:
-                          endpoint:
-                            type: string
-                          regionSecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          bucket:
-                            type: string
-                          accessKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          secretKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                        required:
-                        - bucket
-                        - accessKeySecret
-                        - secretKeySecret
-                        type: object
-                    required:
-                    - s3
-                    type: object
-                  storage:
-                    properties:
-                      size:
-                        type: string
-                      storageClass:
-                        type: string
-                    type: object
-                type: object
             required:
             - host
             type: object
           status:
             properties:
-              readyReplicas:
-                type: integer
               postgresReady:
                 type: boolean
+              readyReplicas:
+                type: integer
             type: object
         type: object
     served: true

--- a/charts/glasskube-operator/templates/miniobuckets.glasskube.eu-v1.yml
+++ b/charts/glasskube-operator/templates/miniobuckets.glasskube.eu-v1.yml
@@ -17,31 +17,31 @@ spec:
         properties:
           spec:
             properties:
-              userSecret:
-                nullable: true
-                properties:
-                  name:
-                    type: string
-                type: object
               bucketNameOverride:
                 nullable: true
                 type: string
               policyOverride:
                 nullable: true
                 type: string
+              userSecret:
+                nullable: true
+                properties:
+                  name:
+                    type: string
+                type: object
             type: object
           status:
             properties:
               bucketCreated:
                 type: boolean
-              username:
-                type: string
-              userCreated:
-                type: boolean
               policyCreated:
                 type: boolean
               policyLinked:
                 type: boolean
+              userCreated:
+                type: boolean
+              username:
+                type: string
             type: object
         type: object
     served: true

--- a/charts/glasskube-operator/templates/nextclouds.glasskube.eu-v1.yml
+++ b/charts/glasskube-operator/templates/nextclouds.glasskube.eu-v1.yml
@@ -17,10 +17,6 @@ spec:
         properties:
           spec:
             properties:
-              host:
-                type: string
-              defaultPhoneRegion:
-                type: string
               apps:
                 properties:
                   office:
@@ -34,6 +30,8 @@ spec:
                   oidc:
                     nullable: true
                     properties:
+                      issuerUrl:
+                        type: string
                       name:
                         type: string
                       oidcSecret:
@@ -41,41 +39,16 @@ spec:
                           name:
                             type: string
                         type: object
-                      issuerUrl:
-                        type: string
                     required:
                     - name
                     - oidcSecret
                     - issuerUrl
                     type: object
                 type: object
-              smtp:
-                nullable: true
-                properties:
-                  host:
-                    type: string
-                  port:
-                    type: integer
-                  fromAddress:
-                    type: string
-                  authSecret:
-                    properties:
-                      name:
-                        type: string
-                    type: object
-                  tlsEnabled:
-                    type: boolean
-                required:
-                - host
-                - fromAddress
-                - authSecret
-                type: object
-              storage:
+              backups:
                 properties:
                   s3:
                     properties:
-                      bucket:
-                        type: string
                       accessKeySecret:
                         properties:
                           key:
@@ -85,6 +58,17 @@ spec:
                           optional:
                             type: boolean
                         type: object
+                      bucket:
+                        type: string
+                      hostname:
+                        nullable: true
+                        type: string
+                      port:
+                        nullable: true
+                        type: integer
+                      region:
+                        nullable: true
+                        type: string
                       secretKeySecret:
                         properties:
                           key:
@@ -94,40 +78,95 @@ spec:
                           optional:
                             type: boolean
                         type: object
-                      region:
-                        nullable: true
-                        type: string
-                      hostname:
-                        nullable: true
-                        type: string
-                      port:
-                        nullable: true
-                        type: integer
-                      objectPrefix:
-                        nullable: true
-                        type: string
-                      autoCreate:
-                        nullable: true
+                      usePathStyle:
                         type: boolean
                       useSsl:
-                        type: boolean
-                      usePathStyle:
-                        nullable: true
-                        type: boolean
-                      legacyAuth:
-                        nullable: true
                         type: boolean
                     required:
                     - bucket
                     - accessKeySecret
                     - secretKeySecret
                     type: object
+                  schedule:
+                    type: string
+                  ttl:
+                    type: string
+                required:
+                - s3
                 type: object
-              version:
-                pattern: \d+\.\d+\.\d+
+              database:
+                nullable: true
+                properties:
+                  backups:
+                    properties:
+                      retentionPolicy:
+                        type: string
+                      s3:
+                        properties:
+                          accessKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          bucket:
+                            type: string
+                          endpoint:
+                            type: string
+                          regionSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          secretKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                        required:
+                        - bucket
+                        - accessKeySecret
+                        - secretKeySecret
+                        type: object
+                      schedule:
+                        type: string
+                    required:
+                    - s3
+                    type: object
+                  instances:
+                    minimum: 1.0
+                    type: integer
+                  storage:
+                    properties:
+                      size:
+                        type: string
+                      storageClass:
+                        type: string
+                    type: object
+                type: object
+              defaultPhoneRegion:
+                type: string
+              host:
                 type: string
               server:
                 properties:
+                  maxChildren:
+                    type: integer
+                  maxSpareServers:
+                    type: integer
+                  minSpareServers:
+                    type: integer
                   resources:
                     nullable: true
                     properties:
@@ -153,86 +192,96 @@ spec:
                           x-kubernetes-int-or-string: true
                         type: object
                     type: object
-                  maxChildren:
-                    type: integer
                   startServers:
                     type: integer
-                  minSpareServers:
-                    type: integer
-                  maxSpareServers:
-                    type: integer
                 type: object
-              database:
+              smtp:
                 nullable: true
                 properties:
-                  instances:
-                    minimum: 1.0
-                    type: integer
-                  backups:
+                  authSecret:
                     properties:
-                      schedule:
+                      name:
                         type: string
-                      retentionPolicy:
-                        type: string
-                      s3:
-                        properties:
-                          endpoint:
-                            type: string
-                          regionSecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          bucket:
-                            type: string
-                          accessKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          secretKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                        required:
-                        - bucket
-                        - accessKeySecret
-                        - secretKeySecret
-                        type: object
-                    required:
-                    - s3
                     type: object
-                  storage:
+                  fromAddress:
+                    type: string
+                  host:
+                    type: string
+                  port:
+                    type: integer
+                  tlsEnabled:
+                    type: boolean
+                required:
+                - host
+                - fromAddress
+                - authSecret
+                type: object
+              storage:
+                properties:
+                  s3:
                     properties:
-                      size:
+                      accessKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      autoCreate:
+                        nullable: true
+                        type: boolean
+                      bucket:
                         type: string
-                      storageClass:
+                      hostname:
+                        nullable: true
                         type: string
+                      legacyAuth:
+                        nullable: true
+                        type: boolean
+                      objectPrefix:
+                        nullable: true
+                        type: string
+                      port:
+                        nullable: true
+                        type: integer
+                      region:
+                        nullable: true
+                        type: string
+                      secretKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      usePathStyle:
+                        nullable: true
+                        type: boolean
+                      useSsl:
+                        type: boolean
+                    required:
+                    - bucket
+                    - accessKeySecret
+                    - secretKeySecret
                     type: object
                 type: object
+              version:
+                pattern: \d+\.\d+\.\d+
+                type: string
             type: object
           status:
             properties:
-              readyReplicas:
-                type: integer
-              redisReady:
+              officeReady:
                 type: boolean
               postgresReady:
                 type: boolean
-              officeReady:
+              readyReplicas:
+                type: integer
+              redisReady:
                 type: boolean
             type: object
         type: object

--- a/charts/glasskube-operator/templates/odoos.glasskube.eu-v1.yml
+++ b/charts/glasskube-operator/templates/odoos.glasskube.eu-v1.yml
@@ -17,10 +17,120 @@ spec:
         properties:
           spec:
             properties:
-              host:
-                type: string
+              backups:
+                properties:
+                  s3:
+                    properties:
+                      accessKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      bucket:
+                        type: string
+                      hostname:
+                        nullable: true
+                        type: string
+                      port:
+                        nullable: true
+                        type: integer
+                      region:
+                        nullable: true
+                        type: string
+                      secretKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      usePathStyle:
+                        type: boolean
+                      useSsl:
+                        type: boolean
+                    required:
+                    - bucket
+                    - accessKeySecret
+                    - secretKeySecret
+                    type: object
+                  schedule:
+                    type: string
+                  ttl:
+                    type: string
+                required:
+                - s3
+                type: object
+              database:
+                nullable: true
+                properties:
+                  backups:
+                    properties:
+                      retentionPolicy:
+                        type: string
+                      s3:
+                        properties:
+                          accessKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          bucket:
+                            type: string
+                          endpoint:
+                            type: string
+                          regionSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          secretKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                        required:
+                        - bucket
+                        - accessKeySecret
+                        - secretKeySecret
+                        type: object
+                      schedule:
+                        type: string
+                    required:
+                    - s3
+                    type: object
+                  instances:
+                    minimum: 1.0
+                    type: integer
+                  storage:
+                    properties:
+                      size:
+                        type: string
+                      storageClass:
+                        type: string
+                    type: object
+                type: object
               demoEnabled:
                 type: boolean
+              host:
+                type: string
               resources:
                 properties:
                   claims:
@@ -48,73 +158,12 @@ spec:
               version:
                 pattern: \d+\.\d+\.\d+
                 type: string
-              database:
-                nullable: true
-                properties:
-                  instances:
-                    minimum: 1.0
-                    type: integer
-                  backups:
-                    properties:
-                      schedule:
-                        type: string
-                      retentionPolicy:
-                        type: string
-                      s3:
-                        properties:
-                          endpoint:
-                            type: string
-                          regionSecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          bucket:
-                            type: string
-                          accessKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          secretKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                        required:
-                        - bucket
-                        - accessKeySecret
-                        - secretKeySecret
-                        type: object
-                    required:
-                    - s3
-                    type: object
-                  storage:
-                    properties:
-                      size:
-                        type: string
-                      storageClass:
-                        type: string
-                    type: object
-                type: object
             type: object
           status:
             properties:
-              ready:
-                type: boolean
               demoEnabledOnInstall:
+                type: boolean
+              ready:
                 type: boolean
             type: object
         type: object

--- a/charts/glasskube-operator/templates/planes.glasskube.eu-v1.yml
+++ b/charts/glasskube-operator/templates/planes.glasskube.eu-v1.yml
@@ -17,10 +17,174 @@ spec:
         properties:
           spec:
             properties:
-              host:
-                type: string
-              registrationEnabled:
-                type: boolean
+              api:
+                properties:
+                  concurrency:
+                    type: integer
+                  resources:
+                    nullable: true
+                    properties:
+                      claims:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                        type: array
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                type: object
+              backups:
+                properties:
+                  s3:
+                    properties:
+                      accessKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      bucket:
+                        type: string
+                      hostname:
+                        nullable: true
+                        type: string
+                      port:
+                        nullable: true
+                        type: integer
+                      region:
+                        nullable: true
+                        type: string
+                      secretKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      usePathStyle:
+                        type: boolean
+                      useSsl:
+                        type: boolean
+                    required:
+                    - bucket
+                    - accessKeySecret
+                    - secretKeySecret
+                    type: object
+                  schedule:
+                    type: string
+                  ttl:
+                    type: string
+                required:
+                - s3
+                type: object
+              beatWorker:
+                properties:
+                  resources:
+                    nullable: true
+                    properties:
+                      claims:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                        type: array
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                type: object
+              database:
+                nullable: true
+                properties:
+                  backups:
+                    properties:
+                      retentionPolicy:
+                        type: string
+                      s3:
+                        properties:
+                          accessKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          bucket:
+                            type: string
+                          endpoint:
+                            type: string
+                          regionSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          secretKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                        required:
+                        - bucket
+                        - accessKeySecret
+                        - secretKeySecret
+                        type: object
+                      schedule:
+                        type: string
+                    required:
+                    - s3
+                    type: object
+                  instances:
+                    minimum: 1.0
+                    type: integer
+                  storage:
+                    properties:
+                      size:
+                        type: string
+                      storageClass:
+                        type: string
+                    type: object
+                type: object
               defaultUser:
                 properties:
                   email:
@@ -59,148 +223,12 @@ spec:
                         type: object
                     type: object
                 type: object
-              space:
-                properties:
-                  resources:
-                    nullable: true
-                    properties:
-                      claims:
-                        items:
-                          properties:
-                            name:
-                              type: string
-                          type: object
-                        type: array
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          x-kubernetes-int-or-string: true
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          x-kubernetes-int-or-string: true
-                        type: object
-                    type: object
-                type: object
-              api:
-                properties:
-                  concurrency:
-                    type: integer
-                  resources:
-                    nullable: true
-                    properties:
-                      claims:
-                        items:
-                          properties:
-                            name:
-                              type: string
-                          type: object
-                        type: array
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          x-kubernetes-int-or-string: true
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          x-kubernetes-int-or-string: true
-                        type: object
-                    type: object
-                type: object
-              beatWorker:
-                properties:
-                  resources:
-                    nullable: true
-                    properties:
-                      claims:
-                        items:
-                          properties:
-                            name:
-                              type: string
-                          type: object
-                        type: array
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          x-kubernetes-int-or-string: true
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          x-kubernetes-int-or-string: true
-                        type: object
-                    type: object
-                type: object
-              worker:
-                properties:
-                  concurrency:
-                    type: integer
-                  resources:
-                    nullable: true
-                    properties:
-                      claims:
-                        items:
-                          properties:
-                            name:
-                              type: string
-                          type: object
-                        type: array
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          x-kubernetes-int-or-string: true
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          x-kubernetes-int-or-string: true
-                        type: object
-                    type: object
-                type: object
-              smtp:
-                properties:
-                  host:
-                    type: string
-                  port:
-                    type: integer
-                  fromAddress:
-                    type: string
-                  authSecret:
-                    properties:
-                      name:
-                        type: string
-                    type: object
-                  tlsEnabled:
-                    type: boolean
-                  sslEnabled:
-                    type: boolean
-                required:
-                - host
-                - fromAddress
-                - authSecret
-                type: object
+              host:
+                type: string
+              registrationEnabled:
+                type: boolean
               s3:
                 properties:
-                  bucket:
-                    type: string
                   accessKeySecret:
                     properties:
                       key:
@@ -210,6 +238,16 @@ spec:
                       optional:
                         type: boolean
                     type: object
+                  bucket:
+                    type: string
+                  hostname:
+                    nullable: true
+                    type: string
+                  port:
+                    nullable: true
+                    type: integer
+                  region:
+                    type: string
                   secretKeySecret:
                     properties:
                       key:
@@ -219,13 +257,10 @@ spec:
                       optional:
                         type: boolean
                     type: object
-                  region:
-                    type: string
-                  endpoint:
-                    nullable: true
-                    type: string
                   usePathStyle:
                     nullable: true
+                    type: boolean
+                  useSsl:
                     type: boolean
                 required:
                 - bucket
@@ -233,67 +268,86 @@ spec:
                 - secretKeySecret
                 - region
                 type: object
+              smtp:
+                properties:
+                  authSecret:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                  fromAddress:
+                    type: string
+                  host:
+                    type: string
+                  port:
+                    type: integer
+                  sslEnabled:
+                    type: boolean
+                  tlsEnabled:
+                    type: boolean
+                required:
+                - host
+                - fromAddress
+                - authSecret
+                type: object
+              space:
+                properties:
+                  resources:
+                    nullable: true
+                    properties:
+                      claims:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                        type: array
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                type: object
               version:
                 type: string
-              database:
-                nullable: true
+              worker:
                 properties:
-                  instances:
-                    minimum: 1.0
+                  concurrency:
                     type: integer
-                  backups:
+                  resources:
+                    nullable: true
                     properties:
-                      schedule:
-                        type: string
-                      retentionPolicy:
-                        type: string
-                      s3:
-                        properties:
-                          endpoint:
-                            type: string
-                          regionSecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          bucket:
-                            type: string
-                          accessKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          secretKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                        required:
-                        - bucket
-                        - accessKeySecret
-                        - secretKeySecret
+                      claims:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                        type: array
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
                         type: object
-                    required:
-                    - s3
-                    type: object
-                  storage:
-                    properties:
-                      size:
-                        type: string
-                      storageClass:
-                        type: string
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                        type: object
                     type: object
                 type: object
             required:
@@ -301,16 +355,6 @@ spec:
             type: object
           status:
             properties:
-              frontend:
-                properties:
-                  ready:
-                    type: boolean
-                type: object
-              space:
-                properties:
-                  ready:
-                    type: boolean
-                type: object
               api:
                 properties:
                   ready:
@@ -321,17 +365,27 @@ spec:
                   ready:
                     type: boolean
                 type: object
-              worker:
-                properties:
-                  ready:
-                    type: boolean
-                type: object
               database:
                 properties:
                   ready:
                     type: boolean
                 type: object
+              frontend:
+                properties:
+                  ready:
+                    type: boolean
+                type: object
               redis:
+                properties:
+                  ready:
+                    type: boolean
+                type: object
+              space:
+                properties:
+                  ready:
+                    type: boolean
+                type: object
+              worker:
                 properties:
                   ready:
                     type: boolean

--- a/charts/glasskube-operator/templates/vaults.glasskube.eu-v1.yml
+++ b/charts/glasskube-operator/templates/vaults.glasskube.eu-v1.yml
@@ -17,17 +17,163 @@ spec:
         properties:
           spec:
             properties:
+              auditStorage:
+                nullable: true
+                properties:
+                  enabled:
+                    type: boolean
+                  size:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    x-kubernetes-int-or-string: true
+                required:
+                - enabled
+                type: object
+              autoUnseal:
+                nullable: true
+                properties:
+                  address:
+                    type: string
+                  authPath:
+                    description: Optional. Default is "kubernetes".
+                    type: string
+                  keyName:
+                    description: Optional. Default is "namespace.name".
+                    type: string
+                  mountPath:
+                    description: Optional. Default is "transit".
+                    type: string
+                  roleName:
+                    description: Optional. Default is "namespace.name".
+                    type: string
+                  tlsCaSecret:
+                    nullable: true
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+                      optional:
+                        type: boolean
+                    type: object
+                required:
+                - address
+                type: object
+              backups:
+                properties:
+                  s3:
+                    properties:
+                      accessKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      bucket:
+                        type: string
+                      hostname:
+                        nullable: true
+                        type: string
+                      port:
+                        nullable: true
+                        type: integer
+                      region:
+                        nullable: true
+                        type: string
+                      secretKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      usePathStyle:
+                        type: boolean
+                      useSsl:
+                        type: boolean
+                    required:
+                    - bucket
+                    - accessKeySecret
+                    - secretKeySecret
+                    type: object
+                  schedule:
+                    type: string
+                  ttl:
+                    type: string
+                required:
+                - s3
+                type: object
+              database:
+                nullable: true
+                properties:
+                  backups:
+                    properties:
+                      retentionPolicy:
+                        type: string
+                      s3:
+                        properties:
+                          accessKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          bucket:
+                            type: string
+                          endpoint:
+                            type: string
+                          regionSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          secretKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                        required:
+                        - bucket
+                        - accessKeySecret
+                        - secretKeySecret
+                        type: object
+                      schedule:
+                        type: string
+                    required:
+                    - s3
+                    type: object
+                  instances:
+                    minimum: 1.0
+                    type: integer
+                  storage:
+                    properties:
+                      size:
+                        type: string
+                      storageClass:
+                        type: string
+                    type: object
+                type: object
               host:
                 type: string
               replicas:
                 type: integer
-              ui:
-                properties:
-                  enabled:
-                    type: boolean
-                required:
-                - enabled
-                type: object
               resources:
                 properties:
                   claims:
@@ -59,122 +205,25 @@ spec:
                 required:
                 - enabled
                 type: object
-              autoUnseal:
-                nullable: true
-                properties:
-                  address:
-                    type: string
-                  tlsCaSecret:
-                    nullable: true
-                    properties:
-                      key:
-                        type: string
-                      name:
-                        type: string
-                      optional:
-                        type: boolean
-                    type: object
-                  authPath:
-                    description: Optional. Default is "kubernetes".
-                    type: string
-                  roleName:
-                    description: Optional. Default is "namespace.name".
-                    type: string
-                  mountPath:
-                    description: Optional. Default is "transit".
-                    type: string
-                  keyName:
-                    description: Optional. Default is "namespace.name".
-                    type: string
-                required:
-                - address
-                type: object
-              auditStorage:
-                nullable: true
+              ui:
                 properties:
                   enabled:
                     type: boolean
-                  size:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    x-kubernetes-int-or-string: true
                 required:
                 - enabled
                 type: object
               version:
                 pattern: \d+\.\d+\.\d+
                 type: string
-              database:
-                nullable: true
-                properties:
-                  instances:
-                    minimum: 1.0
-                    type: integer
-                  backups:
-                    properties:
-                      schedule:
-                        type: string
-                      retentionPolicy:
-                        type: string
-                      s3:
-                        properties:
-                          endpoint:
-                            type: string
-                          regionSecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          bucket:
-                            type: string
-                          accessKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          secretKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                        required:
-                        - bucket
-                        - accessKeySecret
-                        - secretKeySecret
-                        type: object
-                    required:
-                    - s3
-                    type: object
-                  storage:
-                    properties:
-                      size:
-                        type: string
-                      storageClass:
-                        type: string
-                    type: object
-                type: object
             required:
             - host
             type: object
           status:
             properties:
-              readyReplicas:
-                type: integer
               postgresReady:
                 type: boolean
+              readyReplicas:
+                type: integer
             type: object
         type: object
     served: true

--- a/deploy/crd/giteas.glasskube.eu-v1.yml
+++ b/deploy/crd/giteas.glasskube.eu-v1.yml
@@ -17,12 +17,6 @@ spec:
         properties:
           spec:
             properties:
-              host:
-                type: string
-              sshEnabled:
-                type: boolean
-              sshHost:
-                type: string
               adminSecret:
                 description: "Secret containing data of the admin user to create on\
                   \ pod initialization. Expected keys are GITEA_ADMIN_USER, GITEA_ADMIN_EMAIL\
@@ -31,31 +25,122 @@ spec:
                   name:
                     type: string
                 type: object
+              backups:
+                properties:
+                  s3:
+                    properties:
+                      accessKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      bucket:
+                        type: string
+                      hostname:
+                        nullable: true
+                        type: string
+                      port:
+                        nullable: true
+                        type: integer
+                      region:
+                        nullable: true
+                        type: string
+                      secretKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      usePathStyle:
+                        type: boolean
+                      useSsl:
+                        type: boolean
+                    required:
+                    - bucket
+                    - accessKeySecret
+                    - secretKeySecret
+                    type: object
+                  schedule:
+                    type: string
+                  ttl:
+                    type: string
+                required:
+                - s3
+                type: object
+              database:
+                nullable: true
+                properties:
+                  backups:
+                    properties:
+                      retentionPolicy:
+                        type: string
+                      s3:
+                        properties:
+                          accessKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          bucket:
+                            type: string
+                          endpoint:
+                            type: string
+                          regionSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          secretKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                        required:
+                        - bucket
+                        - accessKeySecret
+                        - secretKeySecret
+                        type: object
+                      schedule:
+                        type: string
+                    required:
+                    - s3
+                    type: object
+                  instances:
+                    minimum: 1.0
+                    type: integer
+                  storage:
+                    properties:
+                      size:
+                        type: string
+                      storageClass:
+                        type: string
+                    type: object
+                type: object
+              host:
+                type: string
               registrationEnabled:
                 type: boolean
               replicas:
                 type: integer
-              smtp:
-                nullable: true
-                properties:
-                  host:
-                    type: string
-                  port:
-                    type: integer
-                  fromAddress:
-                    type: string
-                  authSecret:
-                    properties:
-                      name:
-                        type: string
-                    type: object
-                  tlsEnabled:
-                    type: boolean
-                required:
-                - host
-                - fromAddress
-                - authSecret
-                type: object
               resources:
                 properties:
                   claims:
@@ -80,129 +165,44 @@ spec:
                       x-kubernetes-int-or-string: true
                     type: object
                 type: object
+              smtp:
+                nullable: true
+                properties:
+                  authSecret:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                  fromAddress:
+                    type: string
+                  host:
+                    type: string
+                  port:
+                    type: integer
+                  tlsEnabled:
+                    type: boolean
+                required:
+                - host
+                - fromAddress
+                - authSecret
+                type: object
+              sshEnabled:
+                type: boolean
+              sshHost:
+                type: string
               version:
                 pattern: \d+\.\d+\.\d+
                 type: string
-              database:
-                nullable: true
-                properties:
-                  instances:
-                    minimum: 1.0
-                    type: integer
-                  backups:
-                    properties:
-                      schedule:
-                        type: string
-                      retentionPolicy:
-                        type: string
-                      s3:
-                        properties:
-                          endpoint:
-                            type: string
-                          regionSecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          bucket:
-                            type: string
-                          accessKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          secretKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                        required:
-                        - bucket
-                        - accessKeySecret
-                        - secretKeySecret
-                        type: object
-                    required:
-                    - s3
-                    type: object
-                  storage:
-                    properties:
-                      size:
-                        type: string
-                      storageClass:
-                        type: string
-                    type: object
-                type: object
-              backups:
-                properties:
-                  schedule:
-                    type: string
-                  ttl:
-                    type: string
-                  s3:
-                    properties:
-                      hostname:
-                        nullable: true
-                        type: string
-                      port:
-                        nullable: true
-                        type: integer
-                      useSsl:
-                        type: boolean
-                      region:
-                        nullable: true
-                        type: string
-                      bucket:
-                        type: string
-                      accessKeySecret:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        type: object
-                      secretKeySecret:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        type: object
-                      usePathStyle:
-                        type: boolean
-                    required:
-                    - bucket
-                    - accessKeySecret
-                    - secretKeySecret
-                    type: object
-                required:
-                - s3
-                type: object
             required:
             - host
             type: object
           status:
             properties:
+              postgresReady:
+                type: boolean
               readyReplicas:
                 type: integer
               redisReady:
-                type: boolean
-              postgresReady:
                 type: boolean
             type: object
         type: object

--- a/deploy/crd/gitlabrunners.glasskube.eu-v1.yml
+++ b/deploy/crd/gitlabrunners.glasskube.eu-v1.yml
@@ -17,15 +17,15 @@ spec:
         properties:
           spec:
             properties:
-              token:
-                type: string
+              concurrency:
+                type: integer
               gitlab:
                 properties:
                   name:
                     type: string
                 type: object
-              concurrency:
-                type: integer
+              token:
+                type: string
               version:
                 pattern: \d+\.\d+\.\d+
                 type: string

--- a/deploy/crd/gitlabs.glasskube.eu-v1.yml
+++ b/deploy/crd/gitlabs.glasskube.eu-v1.yml
@@ -17,12 +17,118 @@ spec:
         properties:
           spec:
             properties:
+              backups:
+                properties:
+                  s3:
+                    properties:
+                      accessKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      bucket:
+                        type: string
+                      hostname:
+                        nullable: true
+                        type: string
+                      port:
+                        nullable: true
+                        type: integer
+                      region:
+                        nullable: true
+                        type: string
+                      secretKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      usePathStyle:
+                        type: boolean
+                      useSsl:
+                        type: boolean
+                    required:
+                    - bucket
+                    - accessKeySecret
+                    - secretKeySecret
+                    type: object
+                  schedule:
+                    type: string
+                  ttl:
+                    type: string
+                required:
+                - s3
+                type: object
+              database:
+                nullable: true
+                properties:
+                  backups:
+                    properties:
+                      retentionPolicy:
+                        type: string
+                      s3:
+                        properties:
+                          accessKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          bucket:
+                            type: string
+                          endpoint:
+                            type: string
+                          regionSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          secretKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                        required:
+                        - bucket
+                        - accessKeySecret
+                        - secretKeySecret
+                        type: object
+                      schedule:
+                        type: string
+                    required:
+                    - s3
+                    type: object
+                  instances:
+                    minimum: 1.0
+                    type: integer
+                  storage:
+                    properties:
+                      size:
+                        type: string
+                      storageClass:
+                        type: string
+                    type: object
+                type: object
               host:
                 type: string
-              sshHost:
-                type: string
-              sshEnabled:
-                type: boolean
               initialRootPasswordSecret:
                 properties:
                   key:
@@ -32,41 +138,59 @@ spec:
                   optional:
                     type: boolean
                 type: object
-              smtp:
+              omnibusConfigOverride:
+                nullable: true
+                type: string
+              registry:
                 nullable: true
                 properties:
                   host:
                     type: string
-                  port:
-                    type: integer
-                  fromAddress:
-                    type: string
-                  authSecret:
+                  storage:
+                    nullable: true
                     properties:
-                      name:
-                        type: string
+                      s3:
+                        properties:
+                          accessKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          bucket:
+                            type: string
+                          hostname:
+                            type: string
+                          port:
+                            type: integer
+                          region:
+                            type: string
+                          secretKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          usePathStyle:
+                            type: boolean
+                          useSsl:
+                            type: boolean
+                        required:
+                        - bucket
+                        - accessKeySecret
+                        - secretKeySecret
+                        - region
+                        type: object
                     type: object
-                  tlsEnabled:
-                    type: boolean
                 required:
                 - host
-                - fromAddress
-                - authSecret
                 type: object
-              runners:
-                items:
-                  properties:
-                    token:
-                      type: string
-                    concurrency:
-                      type: integer
-                    version:
-                      pattern: \d+\.\d+\.\d+
-                      type: string
-                  required:
-                  - token
-                  type: object
-                type: array
               resources:
                 properties:
                   claims:
@@ -91,181 +215,57 @@ spec:
                       x-kubernetes-int-or-string: true
                     type: object
                 type: object
-              omnibusConfigOverride:
-                nullable: true
-                type: string
-              registry:
+              runners:
+                items:
+                  properties:
+                    concurrency:
+                      type: integer
+                    token:
+                      type: string
+                    version:
+                      pattern: \d+\.\d+\.\d+
+                      type: string
+                  required:
+                  - token
+                  type: object
+                type: array
+              smtp:
                 nullable: true
                 properties:
+                  authSecret:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                  fromAddress:
+                    type: string
                   host:
                     type: string
-                  storage:
-                    nullable: true
-                    properties:
-                      s3:
-                        properties:
-                          bucket:
-                            type: string
-                          accessKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          secretKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          region:
-                            type: string
-                          hostname:
-                            type: string
-                          port:
-                            type: integer
-                          useSsl:
-                            type: boolean
-                          usePathStyle:
-                            type: boolean
-                        required:
-                        - bucket
-                        - accessKeySecret
-                        - secretKeySecret
-                        - region
-                        type: object
-                    type: object
+                  port:
+                    type: integer
+                  tlsEnabled:
+                    type: boolean
                 required:
                 - host
+                - fromAddress
+                - authSecret
                 type: object
+              sshEnabled:
+                type: boolean
+              sshHost:
+                type: string
               version:
                 pattern: \d+\.\d+\.\d+
                 type: string
-              database:
-                nullable: true
-                properties:
-                  instances:
-                    minimum: 1.0
-                    type: integer
-                  backups:
-                    properties:
-                      schedule:
-                        type: string
-                      retentionPolicy:
-                        type: string
-                      s3:
-                        properties:
-                          endpoint:
-                            type: string
-                          regionSecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          bucket:
-                            type: string
-                          accessKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          secretKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                        required:
-                        - bucket
-                        - accessKeySecret
-                        - secretKeySecret
-                        type: object
-                    required:
-                    - s3
-                    type: object
-                  storage:
-                    properties:
-                      size:
-                        type: string
-                      storageClass:
-                        type: string
-                    type: object
-                type: object
-              backups:
-                properties:
-                  schedule:
-                    type: string
-                  ttl:
-                    type: string
-                  s3:
-                    properties:
-                      hostname:
-                        nullable: true
-                        type: string
-                      port:
-                        nullable: true
-                        type: integer
-                      useSsl:
-                        type: boolean
-                      region:
-                        nullable: true
-                        type: string
-                      bucket:
-                        type: string
-                      accessKeySecret:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        type: object
-                      secretKeySecret:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        type: object
-                      usePathStyle:
-                        type: boolean
-                    required:
-                    - bucket
-                    - accessKeySecret
-                    - secretKeySecret
-                    type: object
-                required:
-                - s3
-                type: object
             required:
             - host
             type: object
           status:
             properties:
-              readyReplicas:
-                type: integer
               postgresReady:
                 type: boolean
+              readyReplicas:
+                type: integer
               runners:
                 additionalProperties:
                   properties:

--- a/deploy/crd/glitchtips.glasskube.eu-v1.yml
+++ b/deploy/crd/glitchtips.glasskube.eu-v1.yml
@@ -17,35 +17,124 @@ spec:
         properties:
           spec:
             properties:
-              host:
-                type: string
-              replicas:
-                type: integer
-              registrationEnabled:
-                type: boolean
-              organizationCreationEnabled:
-                type: boolean
-              smtp:
+              backups:
+                properties:
+                  s3:
+                    properties:
+                      accessKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      bucket:
+                        type: string
+                      hostname:
+                        nullable: true
+                        type: string
+                      port:
+                        nullable: true
+                        type: integer
+                      region:
+                        nullable: true
+                        type: string
+                      secretKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      usePathStyle:
+                        type: boolean
+                      useSsl:
+                        type: boolean
+                    required:
+                    - bucket
+                    - accessKeySecret
+                    - secretKeySecret
+                    type: object
+                  schedule:
+                    type: string
+                  ttl:
+                    type: string
+                required:
+                - s3
+                type: object
+              database:
                 nullable: true
                 properties:
-                  host:
-                    type: string
-                  port:
-                    type: integer
-                  fromAddress:
-                    type: string
-                  authSecret:
+                  backups:
                     properties:
-                      name:
+                      retentionPolicy:
+                        type: string
+                      s3:
+                        properties:
+                          accessKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          bucket:
+                            type: string
+                          endpoint:
+                            type: string
+                          regionSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          secretKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                        required:
+                        - bucket
+                        - accessKeySecret
+                        - secretKeySecret
+                        type: object
+                      schedule:
+                        type: string
+                    required:
+                    - s3
+                    type: object
+                  instances:
+                    minimum: 1.0
+                    type: integer
+                  storage:
+                    properties:
+                      size:
+                        type: string
+                      storageClass:
                         type: string
                     type: object
-                  tlsEnabled:
-                    type: boolean
-                required:
-                - host
-                - fromAddress
-                - authSecret
                 type: object
+              host:
+                type: string
+              organizationCreationEnabled:
+                type: boolean
+              registrationEnabled:
+                type: boolean
+              replicas:
+                type: integer
               resources:
                 properties:
                   claims:
@@ -70,132 +159,43 @@ spec:
                       x-kubernetes-int-or-string: true
                     type: object
                 type: object
+              smtp:
+                nullable: true
+                properties:
+                  authSecret:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                  fromAddress:
+                    type: string
+                  host:
+                    type: string
+                  port:
+                    type: integer
+                  tlsEnabled:
+                    type: boolean
+                required:
+                - host
+                - fromAddress
+                - authSecret
+                type: object
               version:
                 pattern: \d+\.\d+\.\d+
                 type: string
-              database:
-                nullable: true
-                properties:
-                  instances:
-                    minimum: 1.0
-                    type: integer
-                  backups:
-                    properties:
-                      schedule:
-                        type: string
-                      retentionPolicy:
-                        type: string
-                      s3:
-                        properties:
-                          endpoint:
-                            type: string
-                          regionSecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          bucket:
-                            type: string
-                          accessKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          secretKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                        required:
-                        - bucket
-                        - accessKeySecret
-                        - secretKeySecret
-                        type: object
-                    required:
-                    - s3
-                    type: object
-                  storage:
-                    properties:
-                      size:
-                        type: string
-                      storageClass:
-                        type: string
-                    type: object
-                type: object
-              backups:
-                properties:
-                  schedule:
-                    type: string
-                  ttl:
-                    type: string
-                  s3:
-                    properties:
-                      hostname:
-                        nullable: true
-                        type: string
-                      port:
-                        nullable: true
-                        type: integer
-                      useSsl:
-                        type: boolean
-                      region:
-                        nullable: true
-                        type: string
-                      bucket:
-                        type: string
-                      accessKeySecret:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        type: object
-                      secretKeySecret:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        type: object
-                      usePathStyle:
-                        type: boolean
-                    required:
-                    - bucket
-                    - accessKeySecret
-                    - secretKeySecret
-                    type: object
-                required:
-                - s3
-                type: object
             required:
             - host
             type: object
           status:
             properties:
+              postgresReady:
+                type: boolean
               readyReplicas:
-                type: integer
-              workerReadyReplicas:
                 type: integer
               redisReady:
                 type: boolean
-              postgresReady:
-                type: boolean
+              workerReadyReplicas:
+                type: integer
             type: object
         type: object
     served: true

--- a/deploy/crd/keycloaks.glasskube.eu-v1.yml
+++ b/deploy/crd/keycloaks.glasskube.eu-v1.yml
@@ -17,8 +17,127 @@ spec:
         properties:
           spec:
             properties:
+              backups:
+                properties:
+                  s3:
+                    properties:
+                      accessKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      bucket:
+                        type: string
+                      hostname:
+                        nullable: true
+                        type: string
+                      port:
+                        nullable: true
+                        type: integer
+                      region:
+                        nullable: true
+                        type: string
+                      secretKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      usePathStyle:
+                        type: boolean
+                      useSsl:
+                        type: boolean
+                    required:
+                    - bucket
+                    - accessKeySecret
+                    - secretKeySecret
+                    type: object
+                  schedule:
+                    type: string
+                  ttl:
+                    type: string
+                required:
+                - s3
+                type: object
+              database:
+                nullable: true
+                properties:
+                  backups:
+                    properties:
+                      retentionPolicy:
+                        type: string
+                      s3:
+                        properties:
+                          accessKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          bucket:
+                            type: string
+                          endpoint:
+                            type: string
+                          regionSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          secretKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                        required:
+                        - bucket
+                        - accessKeySecret
+                        - secretKeySecret
+                        type: object
+                      schedule:
+                        type: string
+                    required:
+                    - s3
+                    type: object
+                  instances:
+                    minimum: 1.0
+                    type: integer
+                  storage:
+                    properties:
+                      size:
+                        type: string
+                      storageClass:
+                        type: string
+                    type: object
+                type: object
               host:
                 type: string
+              image:
+                type: string
+              imagePullSecrets:
+                items:
+                  properties:
+                    name:
+                      type: string
+                  type: object
+                type: array
               management:
                 properties:
                   enabled:
@@ -48,137 +167,18 @@ spec:
                       x-kubernetes-int-or-string: true
                     type: object
                 type: object
-              image:
-                type: string
-              imagePullSecrets:
-                items:
-                  properties:
-                    name:
-                      type: string
-                  type: object
-                type: array
               version:
                 pattern: \d+\.\d+\.\d+
                 type: string
-              database:
-                nullable: true
-                properties:
-                  instances:
-                    minimum: 1.0
-                    type: integer
-                  backups:
-                    properties:
-                      schedule:
-                        type: string
-                      retentionPolicy:
-                        type: string
-                      s3:
-                        properties:
-                          endpoint:
-                            type: string
-                          regionSecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          bucket:
-                            type: string
-                          accessKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          secretKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                        required:
-                        - bucket
-                        - accessKeySecret
-                        - secretKeySecret
-                        type: object
-                    required:
-                    - s3
-                    type: object
-                  storage:
-                    properties:
-                      size:
-                        type: string
-                      storageClass:
-                        type: string
-                    type: object
-                type: object
-              backups:
-                properties:
-                  schedule:
-                    type: string
-                  ttl:
-                    type: string
-                  s3:
-                    properties:
-                      hostname:
-                        nullable: true
-                        type: string
-                      port:
-                        nullable: true
-                        type: integer
-                      useSsl:
-                        type: boolean
-                      region:
-                        nullable: true
-                        type: string
-                      bucket:
-                        type: string
-                      accessKeySecret:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        type: object
-                      secretKeySecret:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        type: object
-                      usePathStyle:
-                        type: boolean
-                    required:
-                    - bucket
-                    - accessKeySecret
-                    - secretKeySecret
-                    type: object
-                required:
-                - s3
-                type: object
             required:
             - host
             type: object
           status:
             properties:
-              readyInstances:
-                type: integer
               postgresReady:
                 type: boolean
+              readyInstances:
+                type: integer
             type: object
         type: object
     served: true

--- a/deploy/crd/matomos.glasskube.eu-v1.yml
+++ b/deploy/crd/matomos.glasskube.eu-v1.yml
@@ -17,29 +17,69 @@ spec:
         properties:
           spec:
             properties:
-              host:
-                type: string
-              smtp:
-                nullable: true
+              backups:
                 properties:
-                  host:
-                    type: string
-                  port:
-                    type: integer
-                  fromAddress:
-                    type: string
-                  authSecret:
+                  s3:
                     properties:
-                      name:
+                      accessKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      bucket:
+                        type: string
+                      hostname:
+                        nullable: true
+                        type: string
+                      port:
+                        nullable: true
+                        type: integer
+                      region:
+                        nullable: true
+                        type: string
+                      secretKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      usePathStyle:
+                        type: boolean
+                      useSsl:
+                        type: boolean
+                    required:
+                    - bucket
+                    - accessKeySecret
+                    - secretKeySecret
+                    type: object
+                  schedule:
+                    type: string
+                  ttl:
+                    type: string
+                required:
+                - s3
+                type: object
+              database:
+                properties:
+                  backups:
+                    type: object
+                  storage:
+                    properties:
+                      size:
+                        type: string
+                      storageClass:
                         type: string
                     type: object
-                  tlsEnabled:
-                    type: boolean
-                required:
-                - host
-                - fromAddress
-                - authSecret
                 type: object
+              host:
+                type: string
               resources:
                 properties:
                   claims:
@@ -64,69 +104,29 @@ spec:
                       x-kubernetes-int-or-string: true
                     type: object
                 type: object
+              smtp:
+                nullable: true
+                properties:
+                  authSecret:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                  fromAddress:
+                    type: string
+                  host:
+                    type: string
+                  port:
+                    type: integer
+                  tlsEnabled:
+                    type: boolean
+                required:
+                - host
+                - fromAddress
+                - authSecret
+                type: object
               version:
                 type: string
-              database:
-                properties:
-                  storage:
-                    properties:
-                      size:
-                        type: string
-                      storageClass:
-                        type: string
-                    type: object
-                  backups:
-                    type: object
-                type: object
-              backups:
-                properties:
-                  schedule:
-                    type: string
-                  ttl:
-                    type: string
-                  s3:
-                    properties:
-                      hostname:
-                        nullable: true
-                        type: string
-                      port:
-                        nullable: true
-                        type: integer
-                      useSsl:
-                        type: boolean
-                      region:
-                        nullable: true
-                        type: string
-                      bucket:
-                        type: string
-                      accessKeySecret:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        type: object
-                      secretKeySecret:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        type: object
-                      usePathStyle:
-                        type: boolean
-                    required:
-                    - bucket
-                    - accessKeySecret
-                    - secretKeySecret
-                    type: object
-                required:
-                - s3
-                type: object
             type: object
           status:
             properties:

--- a/deploy/crd/metabases.glasskube.eu-v1.yml
+++ b/deploy/crd/metabases.glasskube.eu-v1.yml
@@ -17,31 +17,120 @@ spec:
         properties:
           spec:
             properties:
+              backups:
+                properties:
+                  s3:
+                    properties:
+                      accessKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      bucket:
+                        type: string
+                      hostname:
+                        nullable: true
+                        type: string
+                      port:
+                        nullable: true
+                        type: integer
+                      region:
+                        nullable: true
+                        type: string
+                      secretKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      usePathStyle:
+                        type: boolean
+                      useSsl:
+                        type: boolean
+                    required:
+                    - bucket
+                    - accessKeySecret
+                    - secretKeySecret
+                    type: object
+                  schedule:
+                    type: string
+                  ttl:
+                    type: string
+                required:
+                - s3
+                type: object
+              database:
+                nullable: true
+                properties:
+                  backups:
+                    properties:
+                      retentionPolicy:
+                        type: string
+                      s3:
+                        properties:
+                          accessKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          bucket:
+                            type: string
+                          endpoint:
+                            type: string
+                          regionSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          secretKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                        required:
+                        - bucket
+                        - accessKeySecret
+                        - secretKeySecret
+                        type: object
+                      schedule:
+                        type: string
+                    required:
+                    - s3
+                    type: object
+                  instances:
+                    minimum: 1.0
+                    type: integer
+                  storage:
+                    properties:
+                      size:
+                        type: string
+                      storageClass:
+                        type: string
+                    type: object
+                type: object
               host:
                 type: string
               replicas:
                 type: integer
-              smtp:
-                nullable: true
-                properties:
-                  host:
-                    type: string
-                  port:
-                    type: integer
-                  fromAddress:
-                    type: string
-                  authSecret:
-                    properties:
-                      name:
-                        type: string
-                    type: object
-                  tlsEnabled:
-                    type: boolean
-                required:
-                - host
-                - fromAddress
-                - authSecret
-                type: object
               resources:
                 properties:
                   claims:
@@ -66,128 +155,39 @@ spec:
                       x-kubernetes-int-or-string: true
                     type: object
                 type: object
+              smtp:
+                nullable: true
+                properties:
+                  authSecret:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                  fromAddress:
+                    type: string
+                  host:
+                    type: string
+                  port:
+                    type: integer
+                  tlsEnabled:
+                    type: boolean
+                required:
+                - host
+                - fromAddress
+                - authSecret
+                type: object
               version:
                 pattern: \d+\.\d+\.\d+
                 type: string
-              database:
-                nullable: true
-                properties:
-                  instances:
-                    minimum: 1.0
-                    type: integer
-                  backups:
-                    properties:
-                      schedule:
-                        type: string
-                      retentionPolicy:
-                        type: string
-                      s3:
-                        properties:
-                          endpoint:
-                            type: string
-                          regionSecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          bucket:
-                            type: string
-                          accessKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          secretKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                        required:
-                        - bucket
-                        - accessKeySecret
-                        - secretKeySecret
-                        type: object
-                    required:
-                    - s3
-                    type: object
-                  storage:
-                    properties:
-                      size:
-                        type: string
-                      storageClass:
-                        type: string
-                    type: object
-                type: object
-              backups:
-                properties:
-                  schedule:
-                    type: string
-                  ttl:
-                    type: string
-                  s3:
-                    properties:
-                      hostname:
-                        nullable: true
-                        type: string
-                      port:
-                        nullable: true
-                        type: integer
-                      useSsl:
-                        type: boolean
-                      region:
-                        nullable: true
-                        type: string
-                      bucket:
-                        type: string
-                      accessKeySecret:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        type: object
-                      secretKeySecret:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        type: object
-                      usePathStyle:
-                        type: boolean
-                    required:
-                    - bucket
-                    - accessKeySecret
-                    - secretKeySecret
-                    type: object
-                required:
-                - s3
-                type: object
             required:
             - host
             type: object
           status:
             properties:
-              readyReplicas:
-                type: integer
               postgresReady:
                 type: boolean
+              readyReplicas:
+                type: integer
             type: object
         type: object
     served: true

--- a/deploy/crd/miniobuckets.glasskube.eu-v1.yml
+++ b/deploy/crd/miniobuckets.glasskube.eu-v1.yml
@@ -17,31 +17,31 @@ spec:
         properties:
           spec:
             properties:
-              userSecret:
-                nullable: true
-                properties:
-                  name:
-                    type: string
-                type: object
               bucketNameOverride:
                 nullable: true
                 type: string
               policyOverride:
                 nullable: true
                 type: string
+              userSecret:
+                nullable: true
+                properties:
+                  name:
+                    type: string
+                type: object
             type: object
           status:
             properties:
               bucketCreated:
                 type: boolean
-              username:
-                type: string
-              userCreated:
-                type: boolean
               policyCreated:
                 type: boolean
               policyLinked:
                 type: boolean
+              userCreated:
+                type: boolean
+              username:
+                type: string
             type: object
         type: object
     served: true

--- a/deploy/crd/nextclouds.glasskube.eu-v1.yml
+++ b/deploy/crd/nextclouds.glasskube.eu-v1.yml
@@ -17,10 +17,6 @@ spec:
         properties:
           spec:
             properties:
-              host:
-                type: string
-              defaultPhoneRegion:
-                type: string
               apps:
                 properties:
                   office:
@@ -34,6 +30,8 @@ spec:
                   oidc:
                     nullable: true
                     properties:
+                      issuerUrl:
+                        type: string
                       name:
                         type: string
                       oidcSecret:
@@ -41,41 +39,16 @@ spec:
                           name:
                             type: string
                         type: object
-                      issuerUrl:
-                        type: string
                     required:
                     - name
                     - oidcSecret
                     - issuerUrl
                     type: object
                 type: object
-              smtp:
-                nullable: true
-                properties:
-                  host:
-                    type: string
-                  port:
-                    type: integer
-                  fromAddress:
-                    type: string
-                  authSecret:
-                    properties:
-                      name:
-                        type: string
-                    type: object
-                  tlsEnabled:
-                    type: boolean
-                required:
-                - host
-                - fromAddress
-                - authSecret
-                type: object
-              storage:
+              backups:
                 properties:
                   s3:
                     properties:
-                      bucket:
-                        type: string
                       accessKeySecret:
                         properties:
                           key:
@@ -85,6 +58,17 @@ spec:
                           optional:
                             type: boolean
                         type: object
+                      bucket:
+                        type: string
+                      hostname:
+                        nullable: true
+                        type: string
+                      port:
+                        nullable: true
+                        type: integer
+                      region:
+                        nullable: true
+                        type: string
                       secretKeySecret:
                         properties:
                           key:
@@ -94,40 +78,95 @@ spec:
                           optional:
                             type: boolean
                         type: object
-                      region:
-                        nullable: true
-                        type: string
-                      hostname:
-                        nullable: true
-                        type: string
-                      port:
-                        nullable: true
-                        type: integer
-                      objectPrefix:
-                        nullable: true
-                        type: string
-                      autoCreate:
-                        nullable: true
+                      usePathStyle:
                         type: boolean
                       useSsl:
-                        type: boolean
-                      usePathStyle:
-                        nullable: true
-                        type: boolean
-                      legacyAuth:
-                        nullable: true
                         type: boolean
                     required:
                     - bucket
                     - accessKeySecret
                     - secretKeySecret
                     type: object
+                  schedule:
+                    type: string
+                  ttl:
+                    type: string
+                required:
+                - s3
                 type: object
-              version:
-                pattern: \d+\.\d+\.\d+
+              database:
+                nullable: true
+                properties:
+                  backups:
+                    properties:
+                      retentionPolicy:
+                        type: string
+                      s3:
+                        properties:
+                          accessKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          bucket:
+                            type: string
+                          endpoint:
+                            type: string
+                          regionSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          secretKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                        required:
+                        - bucket
+                        - accessKeySecret
+                        - secretKeySecret
+                        type: object
+                      schedule:
+                        type: string
+                    required:
+                    - s3
+                    type: object
+                  instances:
+                    minimum: 1.0
+                    type: integer
+                  storage:
+                    properties:
+                      size:
+                        type: string
+                      storageClass:
+                        type: string
+                    type: object
+                type: object
+              defaultPhoneRegion:
+                type: string
+              host:
                 type: string
               server:
                 properties:
+                  maxChildren:
+                    type: integer
+                  maxSpareServers:
+                    type: integer
+                  minSpareServers:
+                    type: integer
                   resources:
                     nullable: true
                     properties:
@@ -153,97 +192,34 @@ spec:
                           x-kubernetes-int-or-string: true
                         type: object
                     type: object
-                  maxChildren:
-                    type: integer
                   startServers:
                     type: integer
-                  minSpareServers:
-                    type: integer
-                  maxSpareServers:
-                    type: integer
                 type: object
-              database:
+              smtp:
                 nullable: true
                 properties:
-                  instances:
-                    minimum: 1.0
+                  authSecret:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                  fromAddress:
+                    type: string
+                  host:
+                    type: string
+                  port:
                     type: integer
-                  backups:
-                    properties:
-                      schedule:
-                        type: string
-                      retentionPolicy:
-                        type: string
-                      s3:
-                        properties:
-                          endpoint:
-                            type: string
-                          regionSecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          bucket:
-                            type: string
-                          accessKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          secretKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                        required:
-                        - bucket
-                        - accessKeySecret
-                        - secretKeySecret
-                        type: object
-                    required:
-                    - s3
-                    type: object
-                  storage:
-                    properties:
-                      size:
-                        type: string
-                      storageClass:
-                        type: string
-                    type: object
+                  tlsEnabled:
+                    type: boolean
+                required:
+                - host
+                - fromAddress
+                - authSecret
                 type: object
-              backups:
+              storage:
                 properties:
-                  schedule:
-                    type: string
-                  ttl:
-                    type: string
                   s3:
                     properties:
-                      hostname:
-                        nullable: true
-                        type: string
-                      port:
-                        nullable: true
-                        type: integer
-                      useSsl:
-                        type: boolean
-                      region:
-                        nullable: true
-                        type: string
-                      bucket:
-                        type: string
                       accessKeySecret:
                         properties:
                           key:
@@ -253,6 +229,26 @@ spec:
                           optional:
                             type: boolean
                         type: object
+                      autoCreate:
+                        nullable: true
+                        type: boolean
+                      bucket:
+                        type: string
+                      hostname:
+                        nullable: true
+                        type: string
+                      legacyAuth:
+                        nullable: true
+                        type: boolean
+                      objectPrefix:
+                        nullable: true
+                        type: string
+                      port:
+                        nullable: true
+                        type: integer
+                      region:
+                        nullable: true
+                        type: string
                       secretKeySecret:
                         properties:
                           key:
@@ -263,25 +259,29 @@ spec:
                             type: boolean
                         type: object
                       usePathStyle:
+                        nullable: true
+                        type: boolean
+                      useSsl:
                         type: boolean
                     required:
                     - bucket
                     - accessKeySecret
                     - secretKeySecret
                     type: object
-                required:
-                - s3
                 type: object
+              version:
+                pattern: \d+\.\d+\.\d+
+                type: string
             type: object
           status:
             properties:
-              readyReplicas:
-                type: integer
-              redisReady:
+              officeReady:
                 type: boolean
               postgresReady:
                 type: boolean
-              officeReady:
+              readyReplicas:
+                type: integer
+              redisReady:
                 type: boolean
             type: object
         type: object

--- a/deploy/crd/odoos.glasskube.eu-v1.yml
+++ b/deploy/crd/odoos.glasskube.eu-v1.yml
@@ -17,10 +17,120 @@ spec:
         properties:
           spec:
             properties:
-              host:
-                type: string
+              backups:
+                properties:
+                  s3:
+                    properties:
+                      accessKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      bucket:
+                        type: string
+                      hostname:
+                        nullable: true
+                        type: string
+                      port:
+                        nullable: true
+                        type: integer
+                      region:
+                        nullable: true
+                        type: string
+                      secretKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      usePathStyle:
+                        type: boolean
+                      useSsl:
+                        type: boolean
+                    required:
+                    - bucket
+                    - accessKeySecret
+                    - secretKeySecret
+                    type: object
+                  schedule:
+                    type: string
+                  ttl:
+                    type: string
+                required:
+                - s3
+                type: object
+              database:
+                nullable: true
+                properties:
+                  backups:
+                    properties:
+                      retentionPolicy:
+                        type: string
+                      s3:
+                        properties:
+                          accessKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          bucket:
+                            type: string
+                          endpoint:
+                            type: string
+                          regionSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          secretKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                        required:
+                        - bucket
+                        - accessKeySecret
+                        - secretKeySecret
+                        type: object
+                      schedule:
+                        type: string
+                    required:
+                    - s3
+                    type: object
+                  instances:
+                    minimum: 1.0
+                    type: integer
+                  storage:
+                    properties:
+                      size:
+                        type: string
+                      storageClass:
+                        type: string
+                    type: object
+                type: object
               demoEnabled:
                 type: boolean
+              host:
+                type: string
               resources:
                 properties:
                   claims:
@@ -48,122 +158,12 @@ spec:
               version:
                 pattern: \d+\.\d+\.\d+
                 type: string
-              database:
-                nullable: true
-                properties:
-                  instances:
-                    minimum: 1.0
-                    type: integer
-                  backups:
-                    properties:
-                      schedule:
-                        type: string
-                      retentionPolicy:
-                        type: string
-                      s3:
-                        properties:
-                          endpoint:
-                            type: string
-                          regionSecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          bucket:
-                            type: string
-                          accessKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          secretKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                        required:
-                        - bucket
-                        - accessKeySecret
-                        - secretKeySecret
-                        type: object
-                    required:
-                    - s3
-                    type: object
-                  storage:
-                    properties:
-                      size:
-                        type: string
-                      storageClass:
-                        type: string
-                    type: object
-                type: object
-              backups:
-                properties:
-                  schedule:
-                    type: string
-                  ttl:
-                    type: string
-                  s3:
-                    properties:
-                      hostname:
-                        nullable: true
-                        type: string
-                      port:
-                        nullable: true
-                        type: integer
-                      useSsl:
-                        type: boolean
-                      region:
-                        nullable: true
-                        type: string
-                      bucket:
-                        type: string
-                      accessKeySecret:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        type: object
-                      secretKeySecret:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        type: object
-                      usePathStyle:
-                        type: boolean
-                    required:
-                    - bucket
-                    - accessKeySecret
-                    - secretKeySecret
-                    type: object
-                required:
-                - s3
-                type: object
             type: object
           status:
             properties:
-              ready:
-                type: boolean
               demoEnabledOnInstall:
+                type: boolean
+              ready:
                 type: boolean
             type: object
         type: object

--- a/deploy/crd/planes.glasskube.eu-v1.yml
+++ b/deploy/crd/planes.glasskube.eu-v1.yml
@@ -17,10 +17,174 @@ spec:
         properties:
           spec:
             properties:
-              host:
-                type: string
-              registrationEnabled:
-                type: boolean
+              api:
+                properties:
+                  concurrency:
+                    type: integer
+                  resources:
+                    nullable: true
+                    properties:
+                      claims:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                        type: array
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                type: object
+              backups:
+                properties:
+                  s3:
+                    properties:
+                      accessKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      bucket:
+                        type: string
+                      hostname:
+                        nullable: true
+                        type: string
+                      port:
+                        nullable: true
+                        type: integer
+                      region:
+                        nullable: true
+                        type: string
+                      secretKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      usePathStyle:
+                        type: boolean
+                      useSsl:
+                        type: boolean
+                    required:
+                    - bucket
+                    - accessKeySecret
+                    - secretKeySecret
+                    type: object
+                  schedule:
+                    type: string
+                  ttl:
+                    type: string
+                required:
+                - s3
+                type: object
+              beatWorker:
+                properties:
+                  resources:
+                    nullable: true
+                    properties:
+                      claims:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                        type: array
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                type: object
+              database:
+                nullable: true
+                properties:
+                  backups:
+                    properties:
+                      retentionPolicy:
+                        type: string
+                      s3:
+                        properties:
+                          accessKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          bucket:
+                            type: string
+                          endpoint:
+                            type: string
+                          regionSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          secretKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                        required:
+                        - bucket
+                        - accessKeySecret
+                        - secretKeySecret
+                        type: object
+                      schedule:
+                        type: string
+                    required:
+                    - s3
+                    type: object
+                  instances:
+                    minimum: 1.0
+                    type: integer
+                  storage:
+                    properties:
+                      size:
+                        type: string
+                      storageClass:
+                        type: string
+                    type: object
+                type: object
               defaultUser:
                 properties:
                   email:
@@ -59,148 +223,12 @@ spec:
                         type: object
                     type: object
                 type: object
-              space:
-                properties:
-                  resources:
-                    nullable: true
-                    properties:
-                      claims:
-                        items:
-                          properties:
-                            name:
-                              type: string
-                          type: object
-                        type: array
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          x-kubernetes-int-or-string: true
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          x-kubernetes-int-or-string: true
-                        type: object
-                    type: object
-                type: object
-              api:
-                properties:
-                  concurrency:
-                    type: integer
-                  resources:
-                    nullable: true
-                    properties:
-                      claims:
-                        items:
-                          properties:
-                            name:
-                              type: string
-                          type: object
-                        type: array
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          x-kubernetes-int-or-string: true
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          x-kubernetes-int-or-string: true
-                        type: object
-                    type: object
-                type: object
-              beatWorker:
-                properties:
-                  resources:
-                    nullable: true
-                    properties:
-                      claims:
-                        items:
-                          properties:
-                            name:
-                              type: string
-                          type: object
-                        type: array
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          x-kubernetes-int-or-string: true
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          x-kubernetes-int-or-string: true
-                        type: object
-                    type: object
-                type: object
-              worker:
-                properties:
-                  concurrency:
-                    type: integer
-                  resources:
-                    nullable: true
-                    properties:
-                      claims:
-                        items:
-                          properties:
-                            name:
-                              type: string
-                          type: object
-                        type: array
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          x-kubernetes-int-or-string: true
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          x-kubernetes-int-or-string: true
-                        type: object
-                    type: object
-                type: object
-              smtp:
-                properties:
-                  host:
-                    type: string
-                  port:
-                    type: integer
-                  fromAddress:
-                    type: string
-                  authSecret:
-                    properties:
-                      name:
-                        type: string
-                    type: object
-                  tlsEnabled:
-                    type: boolean
-                  sslEnabled:
-                    type: boolean
-                required:
-                - host
-                - fromAddress
-                - authSecret
-                type: object
+              host:
+                type: string
+              registrationEnabled:
+                type: boolean
               s3:
                 properties:
-                  bucket:
-                    type: string
                   accessKeySecret:
                     properties:
                       key:
@@ -210,6 +238,16 @@ spec:
                       optional:
                         type: boolean
                     type: object
+                  bucket:
+                    type: string
+                  hostname:
+                    nullable: true
+                    type: string
+                  port:
+                    nullable: true
+                    type: integer
+                  region:
+                    type: string
                   secretKeySecret:
                     properties:
                       key:
@@ -219,18 +257,10 @@ spec:
                       optional:
                         type: boolean
                     type: object
-                  region:
-                    type: string
-                  hostname:
-                    nullable: true
-                    type: string
-                  port:
-                    nullable: true
-                    type: integer
-                  useSsl:
-                    type: boolean
                   usePathStyle:
                     nullable: true
+                    type: boolean
+                  useSsl:
                     type: boolean
                 required:
                 - bucket
@@ -238,133 +268,93 @@ spec:
                 - secretKeySecret
                 - region
                 type: object
-              version:
-                type: string
-              database:
-                nullable: true
+              smtp:
                 properties:
-                  instances:
-                    minimum: 1.0
-                    type: integer
-                  backups:
+                  authSecret:
                     properties:
-                      schedule:
+                      name:
                         type: string
-                      retentionPolicy:
-                        type: string
-                      s3:
-                        properties:
-                          endpoint:
-                            type: string
-                          regionSecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          bucket:
-                            type: string
-                          accessKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          secretKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                        required:
-                        - bucket
-                        - accessKeySecret
-                        - secretKeySecret
-                        type: object
-                    required:
-                    - s3
                     type: object
-                  storage:
+                  fromAddress:
+                    type: string
+                  host:
+                    type: string
+                  port:
+                    type: integer
+                  sslEnabled:
+                    type: boolean
+                  tlsEnabled:
+                    type: boolean
+                required:
+                - host
+                - fromAddress
+                - authSecret
+                type: object
+              space:
+                properties:
+                  resources:
+                    nullable: true
                     properties:
-                      size:
-                        type: string
-                      storageClass:
-                        type: string
+                      claims:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                        type: array
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                        type: object
                     type: object
                 type: object
-              backups:
+              version:
+                type: string
+              worker:
                 properties:
-                  schedule:
-                    type: string
-                  ttl:
-                    type: string
-                  s3:
+                  concurrency:
+                    type: integer
+                  resources:
+                    nullable: true
                     properties:
-                      hostname:
-                        nullable: true
-                        type: string
-                      port:
-                        nullable: true
-                        type: integer
-                      useSsl:
-                        type: boolean
-                      region:
-                        nullable: true
-                        type: string
-                      bucket:
-                        type: string
-                      accessKeySecret:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
+                      claims:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                        type: array
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
                         type: object
-                      secretKeySecret:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
                         type: object
-                      usePathStyle:
-                        type: boolean
-                    required:
-                    - bucket
-                    - accessKeySecret
-                    - secretKeySecret
                     type: object
-                required:
-                - s3
                 type: object
             required:
             - host
             type: object
           status:
             properties:
-              frontend:
-                properties:
-                  ready:
-                    type: boolean
-                type: object
-              space:
-                properties:
-                  ready:
-                    type: boolean
-                type: object
               api:
                 properties:
                   ready:
@@ -375,17 +365,27 @@ spec:
                   ready:
                     type: boolean
                 type: object
-              worker:
-                properties:
-                  ready:
-                    type: boolean
-                type: object
               database:
                 properties:
                   ready:
                     type: boolean
                 type: object
+              frontend:
+                properties:
+                  ready:
+                    type: boolean
+                type: object
               redis:
+                properties:
+                  ready:
+                    type: boolean
+                type: object
+              space:
+                properties:
+                  ready:
+                    type: boolean
+                type: object
+              worker:
                 properties:
                   ready:
                     type: boolean

--- a/deploy/crd/vaults.glasskube.eu-v1.yml
+++ b/deploy/crd/vaults.glasskube.eu-v1.yml
@@ -17,17 +17,163 @@ spec:
         properties:
           spec:
             properties:
+              auditStorage:
+                nullable: true
+                properties:
+                  enabled:
+                    type: boolean
+                  size:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    x-kubernetes-int-or-string: true
+                required:
+                - enabled
+                type: object
+              autoUnseal:
+                nullable: true
+                properties:
+                  address:
+                    type: string
+                  authPath:
+                    description: Optional. Default is "kubernetes".
+                    type: string
+                  keyName:
+                    description: Optional. Default is "namespace.name".
+                    type: string
+                  mountPath:
+                    description: Optional. Default is "transit".
+                    type: string
+                  roleName:
+                    description: Optional. Default is "namespace.name".
+                    type: string
+                  tlsCaSecret:
+                    nullable: true
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+                      optional:
+                        type: boolean
+                    type: object
+                required:
+                - address
+                type: object
+              backups:
+                properties:
+                  s3:
+                    properties:
+                      accessKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      bucket:
+                        type: string
+                      hostname:
+                        nullable: true
+                        type: string
+                      port:
+                        nullable: true
+                        type: integer
+                      region:
+                        nullable: true
+                        type: string
+                      secretKeySecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      usePathStyle:
+                        type: boolean
+                      useSsl:
+                        type: boolean
+                    required:
+                    - bucket
+                    - accessKeySecret
+                    - secretKeySecret
+                    type: object
+                  schedule:
+                    type: string
+                  ttl:
+                    type: string
+                required:
+                - s3
+                type: object
+              database:
+                nullable: true
+                properties:
+                  backups:
+                    properties:
+                      retentionPolicy:
+                        type: string
+                      s3:
+                        properties:
+                          accessKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          bucket:
+                            type: string
+                          endpoint:
+                            type: string
+                          regionSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          secretKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                        required:
+                        - bucket
+                        - accessKeySecret
+                        - secretKeySecret
+                        type: object
+                      schedule:
+                        type: string
+                    required:
+                    - s3
+                    type: object
+                  instances:
+                    minimum: 1.0
+                    type: integer
+                  storage:
+                    properties:
+                      size:
+                        type: string
+                      storageClass:
+                        type: string
+                    type: object
+                type: object
               host:
                 type: string
               replicas:
                 type: integer
-              ui:
-                properties:
-                  enabled:
-                    type: boolean
-                required:
-                - enabled
-                type: object
               resources:
                 properties:
                   claims:
@@ -59,171 +205,25 @@ spec:
                 required:
                 - enabled
                 type: object
-              autoUnseal:
-                nullable: true
-                properties:
-                  address:
-                    type: string
-                  tlsCaSecret:
-                    nullable: true
-                    properties:
-                      key:
-                        type: string
-                      name:
-                        type: string
-                      optional:
-                        type: boolean
-                    type: object
-                  authPath:
-                    description: Optional. Default is "kubernetes".
-                    type: string
-                  roleName:
-                    description: Optional. Default is "namespace.name".
-                    type: string
-                  mountPath:
-                    description: Optional. Default is "transit".
-                    type: string
-                  keyName:
-                    description: Optional. Default is "namespace.name".
-                    type: string
-                required:
-                - address
-                type: object
-              auditStorage:
-                nullable: true
+              ui:
                 properties:
                   enabled:
                     type: boolean
-                  size:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    x-kubernetes-int-or-string: true
                 required:
                 - enabled
                 type: object
               version:
                 pattern: \d+\.\d+\.\d+
                 type: string
-              database:
-                nullable: true
-                properties:
-                  instances:
-                    minimum: 1.0
-                    type: integer
-                  backups:
-                    properties:
-                      schedule:
-                        type: string
-                      retentionPolicy:
-                        type: string
-                      s3:
-                        properties:
-                          endpoint:
-                            type: string
-                          regionSecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          bucket:
-                            type: string
-                          accessKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          secretKeySecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                        required:
-                        - bucket
-                        - accessKeySecret
-                        - secretKeySecret
-                        type: object
-                    required:
-                    - s3
-                    type: object
-                  storage:
-                    properties:
-                      size:
-                        type: string
-                      storageClass:
-                        type: string
-                    type: object
-                type: object
-              backups:
-                properties:
-                  schedule:
-                    type: string
-                  ttl:
-                    type: string
-                  s3:
-                    properties:
-                      hostname:
-                        nullable: true
-                        type: string
-                      port:
-                        nullable: true
-                        type: integer
-                      useSsl:
-                        type: boolean
-                      region:
-                        nullable: true
-                        type: string
-                      bucket:
-                        type: string
-                      accessKeySecret:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        type: object
-                      secretKeySecret:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        type: object
-                      usePathStyle:
-                        type: boolean
-                    required:
-                    - bucket
-                    - accessKeySecret
-                    - secretKeySecret
-                    type: object
-                required:
-                - s3
-                type: object
             required:
             - host
             type: object
           status:
             properties:
-              readyReplicas:
-                type: integer
               postgresReady:
                 type: boolean
+              readyReplicas:
+                type: integer
             type: object
         type: object
     served: true

--- a/operator/src/main/resources/application.yaml
+++ b/operator/src/main/resources/application.yaml
@@ -1,5 +1,2 @@
-#logging:
-#  level:
-#    org.springframework: DEBUG
 velero:
   namespace: velero


### PR DESCRIPTION
particularly, the CRD generator now sorts properties in a different way (see https://github.com/fabric8io/kubernetes-client/issues/5388). Functionality should be unchanged.