### PR TITLE
fix: add label selector to all event sources

### DIFF
--- a/operator/src/main/kotlin/eu/glasskube/operator/api/reconciler/EventSource.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/api/reconciler/EventSource.kt
@@ -6,9 +6,23 @@ import io.javaoperatorsdk.operator.api.config.informer.InformerConfiguration.Inf
 import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext
 import io.javaoperatorsdk.operator.processing.event.source.informer.InformerEventSource
 
+/**
+ * Creates a new InformerEventSource from this context.
+ *
+ * @param labelSelector
+ * Kubernetes label selector the event source should use.
+ * While not required by the Informer API, we enforce setting a label selector
+ * to prevent accidentally getting too many resources from the Kubernetes API.
+ * @param customizer
+ * Can be used to make additional changes to the InformerConfiguration. (optional)
+ */
 inline fun <reified T : HasMetadata> EventSourceContext<*>.informerEventSource(
+    labelSelector: String,
     customizer: InformerConfigurationBuilder<T>.() -> Unit = {}
 ) = InformerEventSource(
-    InformerConfiguration.from(T::class.java, this).apply(customizer).build(),
+    InformerConfiguration.from(T::class.java, this)
+        .withLabelSelector(labelSelector)
+        .apply(customizer)
+        .build(),
     this
 )

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/gitea/dependent/GiteaRedisDeployment.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/gitea/dependent/GiteaRedisDeployment.kt
@@ -3,17 +3,13 @@ package eu.glasskube.operator.apps.gitea.dependent
 import eu.glasskube.kubernetes.api.model.namespace
 import eu.glasskube.operator.apps.gitea.Gitea
 import eu.glasskube.operator.apps.gitea.Gitea.Redis.redisName
-import eu.glasskube.operator.apps.gitea.GiteaReconciler
 import eu.glasskube.operator.generic.dependent.redis.RedisDeployment
 import io.fabric8.kubernetes.api.model.apps.Deployment
 import io.javaoperatorsdk.operator.api.reconciler.ResourceIDMatcherDiscriminator
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 import io.javaoperatorsdk.operator.processing.event.ResourceID
 
-@KubernetesDependent(
-    labelSelector = GiteaReconciler.REDIS_SELECTOR,
-    resourceDiscriminator = GiteaRedisDeployment.Discriminator::class
-)
+@KubernetesDependent(resourceDiscriminator = GiteaRedisDeployment.Discriminator::class)
 class GiteaRedisDeployment : RedisDeployment<Gitea>() {
     override val redisNameMapper = Gitea.Redis
 

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/gitea/dependent/GiteaRedisService.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/gitea/dependent/GiteaRedisService.kt
@@ -3,17 +3,13 @@ package eu.glasskube.operator.apps.gitea.dependent
 import eu.glasskube.kubernetes.api.model.namespace
 import eu.glasskube.operator.apps.gitea.Gitea
 import eu.glasskube.operator.apps.gitea.Gitea.Redis.redisName
-import eu.glasskube.operator.apps.gitea.GiteaReconciler
 import eu.glasskube.operator.generic.dependent.redis.RedisService
 import io.fabric8.kubernetes.api.model.Service
 import io.javaoperatorsdk.operator.api.reconciler.ResourceIDMatcherDiscriminator
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 import io.javaoperatorsdk.operator.processing.event.ResourceID
 
-@KubernetesDependent(
-    labelSelector = GiteaReconciler.REDIS_SELECTOR,
-    resourceDiscriminator = GiteaRedisService.Discriminator::class
-)
+@KubernetesDependent(resourceDiscriminator = GiteaRedisService.Discriminator::class)
 class GiteaRedisService : RedisService<Gitea>() {
     override val redisNameMapper = Gitea.Redis
 

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/gitea/dependent/GiteaVeleroBackupStorageLocation.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/gitea/dependent/GiteaVeleroBackupStorageLocation.kt
@@ -1,8 +1,9 @@
 package eu.glasskube.operator.apps.gitea.dependent
 
 import eu.glasskube.operator.apps.gitea.Gitea
+import eu.glasskube.operator.apps.gitea.GiteaReconciler
 import eu.glasskube.operator.generic.dependent.backups.DependentVeleroBackupStorageLocation
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 
-@KubernetesDependent
+@KubernetesDependent(labelSelector = GiteaReconciler.SELECTOR)
 class GiteaVeleroBackupStorageLocation : DependentVeleroBackupStorageLocation<Gitea>()

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/gitea/dependent/GiteaVeleroSchedule.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/gitea/dependent/GiteaVeleroSchedule.kt
@@ -1,8 +1,9 @@
 package eu.glasskube.operator.apps.gitea.dependent
 
 import eu.glasskube.operator.apps.gitea.Gitea
+import eu.glasskube.operator.apps.gitea.GiteaReconciler
 import eu.glasskube.operator.generic.dependent.backups.DependentVeleroSchedule
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 
-@KubernetesDependent
+@KubernetesDependent(labelSelector = GiteaReconciler.SELECTOR)
 class GiteaVeleroSchedule : DependentVeleroSchedule<Gitea>()

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/gitlab/GitlabReconciler.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/gitlab/GitlabReconciler.kt
@@ -128,8 +128,8 @@ class GitlabReconciler(webhookService: WebhookService) :
 
     override fun prepareEventSources(context: EventSourceContext<Gitlab>) = with(context) {
         mutableMapOf(
-            SERVICE_EVENT_SOURCE to informerEventSource<Service>(),
-            INGRESS_EVENT_SOURCE to informerEventSource<Ingress>()
+            SERVICE_EVENT_SOURCE to informerEventSource<Service>(SELECTOR),
+            INGRESS_EVENT_SOURCE to informerEventSource<Ingress>(SELECTOR)
         )
     }
 

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/gitlab/dependent/GitlabRunners.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/gitlab/dependent/GitlabRunners.kt
@@ -2,6 +2,7 @@ package eu.glasskube.operator.apps.gitlab.dependent
 
 import eu.glasskube.kubernetes.api.model.metadata
 import eu.glasskube.operator.apps.gitlab.Gitlab
+import eu.glasskube.operator.apps.gitlab.GitlabReconciler
 import eu.glasskube.operator.apps.gitlab.GitlabRunnerSpecTemplate
 import eu.glasskube.operator.apps.gitlab.resourceLabels
 import eu.glasskube.operator.apps.gitlab.runner.GitlabRunner
@@ -13,7 +14,9 @@ import io.javaoperatorsdk.operator.api.reconciler.Context
 import io.javaoperatorsdk.operator.processing.dependent.BulkDependentResource
 import io.javaoperatorsdk.operator.processing.dependent.Matcher
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUDKubernetesDependentResource
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 
+@KubernetesDependent(labelSelector = GitlabReconciler.SELECTOR)
 class GitlabRunners :
     CRUDKubernetesDependentResource<GitlabRunner, Gitlab>(GitlabRunner::class.java),
     BulkDependentResource<GitlabRunner, Gitlab> {

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/gitlab/dependent/GitlabVeleroBackupStorageLocation.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/gitlab/dependent/GitlabVeleroBackupStorageLocation.kt
@@ -1,8 +1,9 @@
 package eu.glasskube.operator.apps.gitlab.dependent
 
 import eu.glasskube.operator.apps.gitlab.Gitlab
+import eu.glasskube.operator.apps.gitlab.GitlabReconciler
 import eu.glasskube.operator.generic.dependent.backups.DependentVeleroBackupStorageLocation
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 
-@KubernetesDependent
+@KubernetesDependent(labelSelector = GitlabReconciler.SELECTOR)
 class GitlabVeleroBackupStorageLocation : DependentVeleroBackupStorageLocation<Gitlab>()

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/gitlab/dependent/GitlabVeleroSchedule.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/gitlab/dependent/GitlabVeleroSchedule.kt
@@ -1,8 +1,9 @@
 package eu.glasskube.operator.apps.gitlab.dependent
 
 import eu.glasskube.operator.apps.gitlab.Gitlab
+import eu.glasskube.operator.apps.gitlab.GitlabReconciler
 import eu.glasskube.operator.generic.dependent.backups.DependentVeleroSchedule
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 
-@KubernetesDependent
+@KubernetesDependent(labelSelector = GitlabReconciler.SELECTOR)
 class GitlabVeleroSchedule : DependentVeleroSchedule<Gitlab>()

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/gitlab/dependent/GitlabVeleroSecret.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/gitlab/dependent/GitlabVeleroSecret.kt
@@ -1,12 +1,13 @@
 package eu.glasskube.operator.apps.gitlab.dependent
 
 import eu.glasskube.operator.apps.gitlab.Gitlab
+import eu.glasskube.operator.apps.gitlab.GitlabReconciler
 import eu.glasskube.operator.generic.dependent.backups.BackupSpecNotNullCondition
 import eu.glasskube.operator.generic.dependent.backups.DependentVeleroSecret
 import io.fabric8.kubernetes.api.model.Secret
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 
-@KubernetesDependent
+@KubernetesDependent(labelSelector = GitlabReconciler.SELECTOR)
 class GitlabVeleroSecret : DependentVeleroSecret<Gitlab>() {
     internal class ReconcilePrecondition : BackupSpecNotNullCondition<Secret, Gitlab>()
 }

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/gitlab/runner/GitlabRunnerReconciler.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/gitlab/runner/GitlabRunnerReconciler.kt
@@ -1,5 +1,6 @@
 package eu.glasskube.operator.apps.gitlab.runner
 
+import eu.glasskube.kubernetes.api.model.loggingId
 import eu.glasskube.kubernetes.client.patchOrUpdateStatus
 import eu.glasskube.operator.Labels
 import eu.glasskube.operator.api.reconciler.getSecondaryResource
@@ -24,7 +25,7 @@ import io.javaoperatorsdk.operator.api.reconciler.dependent.Dependent
 )
 class GitlabRunnerReconciler : Reconciler<GitlabRunner> {
     override fun reconcile(resource: GitlabRunner, context: Context<GitlabRunner>): UpdateControl<GitlabRunner> {
-        log.info("Reconciling ${resource.metadata.name}@${resource.metadata.namespace}")
+        log.debug("Reconciling {}", resource.loggingId)
         val readyReplicas = context.getSecondaryResource<Deployment>()
             .map { it.status?.readyReplicas ?: 0 }
             .orElse(0)

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/glitchtip/dependent/GlitchtipVeleroBackupStorageLocation.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/glitchtip/dependent/GlitchtipVeleroBackupStorageLocation.kt
@@ -1,8 +1,9 @@
 package eu.glasskube.operator.apps.glitchtip.dependent
 
 import eu.glasskube.operator.apps.glitchtip.Glitchtip
+import eu.glasskube.operator.apps.glitchtip.GlitchtipReconciler
 import eu.glasskube.operator.generic.dependent.backups.DependentVeleroBackupStorageLocation
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 
-@KubernetesDependent
+@KubernetesDependent(labelSelector = GlitchtipReconciler.SELECTOR)
 class GlitchtipVeleroBackupStorageLocation : DependentVeleroBackupStorageLocation<Glitchtip>()

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/glitchtip/dependent/GlitchtipVeleroSchedule.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/glitchtip/dependent/GlitchtipVeleroSchedule.kt
@@ -1,8 +1,9 @@
 package eu.glasskube.operator.apps.glitchtip.dependent
 
 import eu.glasskube.operator.apps.glitchtip.Glitchtip
+import eu.glasskube.operator.apps.glitchtip.GlitchtipReconciler
 import eu.glasskube.operator.generic.dependent.backups.DependentVeleroSchedule
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 
-@KubernetesDependent
+@KubernetesDependent(labelSelector = GlitchtipReconciler.SELECTOR)
 class GlitchtipVeleroSchedule : DependentVeleroSchedule<Glitchtip>()

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/keycloak/KeycloakReconciler.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/keycloak/KeycloakReconciler.kt
@@ -90,7 +90,7 @@ class KeycloakReconciler(webhookService: WebhookService) :
     }
 
     override fun prepareEventSources(context: EventSourceContext<Keycloak>) = with(context) {
-        mutableMapOf(SERVICE_EVENT_SOURCE to informerEventSource<Service>())
+        mutableMapOf(SERVICE_EVENT_SOURCE to informerEventSource<Service>(SELECTOR))
     }
 
     companion object {

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/keycloak/dependent/KeycloakIngress.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/keycloak/dependent/KeycloakIngress.kt
@@ -9,6 +9,7 @@ import eu.glasskube.kubernetes.api.model.extensions.spec
 import eu.glasskube.kubernetes.api.model.metadata
 import eu.glasskube.kubernetes.api.model.namespace
 import eu.glasskube.operator.apps.keycloak.Keycloak
+import eu.glasskube.operator.apps.keycloak.KeycloakReconciler
 import eu.glasskube.operator.apps.keycloak.genericResourceName
 import eu.glasskube.operator.apps.keycloak.ingressTlsCertName
 import eu.glasskube.operator.apps.keycloak.resourceLabels
@@ -16,7 +17,9 @@ import eu.glasskube.operator.config.ConfigService
 import eu.glasskube.operator.generic.dependent.DependentIngress
 import io.fabric8.kubernetes.api.model.networking.v1.IngressTLS
 import io.javaoperatorsdk.operator.api.reconciler.Context
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 
+@KubernetesDependent(labelSelector = KeycloakReconciler.SELECTOR)
 class KeycloakIngress(configService: ConfigService) : DependentIngress<Keycloak>(configService) {
     override fun desired(primary: Keycloak, context: Context<Keycloak>) = ingress {
         metadata {

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/keycloak/dependent/KeycloakPostgresCluster.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/keycloak/dependent/KeycloakPostgresCluster.kt
@@ -1,10 +1,13 @@
 package eu.glasskube.operator.apps.keycloak.dependent
 
 import eu.glasskube.operator.apps.keycloak.Keycloak
+import eu.glasskube.operator.apps.keycloak.KeycloakReconciler
 import eu.glasskube.operator.config.ConfigService
 import eu.glasskube.operator.generic.condition.PostgresReadyCondition
 import eu.glasskube.operator.generic.dependent.postgres.DependentPostgresCluster
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 
+@KubernetesDependent(labelSelector = KeycloakReconciler.SELECTOR)
 class KeycloakPostgresCluster(configService: ConfigService) :
     DependentPostgresCluster<Keycloak>(Keycloak.Postgres, configService) {
     class ReadyCondition : PostgresReadyCondition<Keycloak>()

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/keycloak/dependent/KeycloakVeleroBackupStorageLocation.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/keycloak/dependent/KeycloakVeleroBackupStorageLocation.kt
@@ -1,8 +1,9 @@
 package eu.glasskube.operator.apps.keycloak.dependent
 
 import eu.glasskube.operator.apps.keycloak.Keycloak
+import eu.glasskube.operator.apps.keycloak.KeycloakReconciler
 import eu.glasskube.operator.generic.dependent.backups.DependentVeleroBackupStorageLocation
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 
-@KubernetesDependent
+@KubernetesDependent(labelSelector = KeycloakReconciler.SELECTOR)
 class KeycloakVeleroBackupStorageLocation : DependentVeleroBackupStorageLocation<Keycloak>()

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/keycloak/dependent/KeycloakVeleroSchedule.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/keycloak/dependent/KeycloakVeleroSchedule.kt
@@ -1,8 +1,9 @@
 package eu.glasskube.operator.apps.keycloak.dependent
 
 import eu.glasskube.operator.apps.keycloak.Keycloak
+import eu.glasskube.operator.apps.keycloak.KeycloakReconciler
 import eu.glasskube.operator.generic.dependent.backups.DependentVeleroSchedule
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 
-@KubernetesDependent
+@KubernetesDependent(labelSelector = KeycloakReconciler.SELECTOR)
 class KeycloakVeleroSchedule : DependentVeleroSchedule<Keycloak>()

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/keycloak/dependent/KeycloakVeleroSecret.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/keycloak/dependent/KeycloakVeleroSecret.kt
@@ -1,12 +1,13 @@
 package eu.glasskube.operator.apps.keycloak.dependent
 
 import eu.glasskube.operator.apps.keycloak.Keycloak
+import eu.glasskube.operator.apps.keycloak.KeycloakReconciler
 import eu.glasskube.operator.generic.dependent.backups.BackupSpecNotNullCondition
 import eu.glasskube.operator.generic.dependent.backups.DependentVeleroSecret
 import io.fabric8.kubernetes.api.model.Secret
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 
-@KubernetesDependent
+@KubernetesDependent(labelSelector = KeycloakReconciler.SELECTOR)
 class KeycloakVeleroSecret : DependentVeleroSecret<Keycloak>() {
     internal class ReconcilePrecondition : BackupSpecNotNullCondition<Secret, Keycloak>()
 }

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/matomo/MatomoReconciler.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/matomo/MatomoReconciler.kt
@@ -106,7 +106,7 @@ class MatomoReconciler(private val kubernetesClient: KubernetesClient, webhookSe
 
     override fun prepareEventSources(context: EventSourceContext<Matomo>) = with(context) {
         mapOf(
-            SECRET_EVENT_SOURCE to informerEventSource<Secret> {
+            SECRET_EVENT_SOURCE to informerEventSource<Secret>(SELECTOR) {
                 withSecondaryToPrimaryMapper(
                     CompositeSecondaryToPrimaryMapper(
                         Mappers.fromOwnerReference(),

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/matomo/dependent/MatomoVeleroBackupStorageLocation.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/matomo/dependent/MatomoVeleroBackupStorageLocation.kt
@@ -1,8 +1,9 @@
 package eu.glasskube.operator.apps.matomo.dependent
 
 import eu.glasskube.operator.apps.matomo.Matomo
+import eu.glasskube.operator.apps.matomo.MatomoReconciler
 import eu.glasskube.operator.generic.dependent.backups.DependentVeleroBackupStorageLocation
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 
-@KubernetesDependent
+@KubernetesDependent(labelSelector = MatomoReconciler.SELECTOR)
 class MatomoVeleroBackupStorageLocation : DependentVeleroBackupStorageLocation<Matomo>()

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/matomo/dependent/MatomoVeleroSchedule.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/matomo/dependent/MatomoVeleroSchedule.kt
@@ -1,8 +1,9 @@
 package eu.glasskube.operator.apps.matomo.dependent
 
 import eu.glasskube.operator.apps.matomo.Matomo
+import eu.glasskube.operator.apps.matomo.MatomoReconciler
 import eu.glasskube.operator.generic.dependent.backups.DependentVeleroSchedule
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 
-@KubernetesDependent
+@KubernetesDependent(labelSelector = MatomoReconciler.SELECTOR)
 class MatomoVeleroSchedule : DependentVeleroSchedule<Matomo>()

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/metabase/MetabaseReconciler.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/metabase/MetabaseReconciler.kt
@@ -20,7 +20,6 @@ import eu.glasskube.operator.generic.BaseReconciler
 import eu.glasskube.operator.infra.postgres.PostgresCluster
 import eu.glasskube.operator.processing.CompositeSecondaryToPrimaryMapper
 import eu.glasskube.operator.webhook.WebhookService
-import eu.glasskube.utils.logger
 import io.fabric8.kubernetes.api.model.Secret
 import io.fabric8.kubernetes.api.model.apps.Deployment
 import io.javaoperatorsdk.operator.api.reconciler.Context
@@ -108,7 +107,7 @@ class MetabaseReconciler(webhookService: WebhookService) :
 
     override fun prepareEventSources(context: EventSourceContext<Metabase>) = with(context) {
         mutableMapOf(
-            SECRET_EVENT_SOURCE to informerEventSource<Secret> {
+            SECRET_EVENT_SOURCE to informerEventSource<Secret>(SELECTOR) {
                 withSecondaryToPrimaryMapper(
                     CompositeSecondaryToPrimaryMapper(
                         Mappers.fromOwnerReference(),
@@ -124,8 +123,5 @@ class MetabaseReconciler(webhookService: WebhookService) :
             "${Labels.MANAGED_BY_GLASSKUBE},${Labels.PART_OF}=${Metabase.APP_NAME},${Labels.NAME}=${Metabase.APP_NAME}"
 
         internal const val SECRET_EVENT_SOURCE = "MetabaseSecretEventSource"
-
-        @JvmStatic
-        private val log = logger()
     }
 }

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/metabase/dependent/MetabaseVeleroBackupStorageLocation.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/metabase/dependent/MetabaseVeleroBackupStorageLocation.kt
@@ -1,8 +1,9 @@
 package eu.glasskube.operator.apps.metabase.dependent
 
 import eu.glasskube.operator.apps.metabase.Metabase
+import eu.glasskube.operator.apps.metabase.MetabaseReconciler
 import eu.glasskube.operator.generic.dependent.backups.DependentVeleroBackupStorageLocation
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 
-@KubernetesDependent
+@KubernetesDependent(labelSelector = MetabaseReconciler.SELECTOR)
 class MetabaseVeleroBackupStorageLocation : DependentVeleroBackupStorageLocation<Metabase>()

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/metabase/dependent/MetabaseVeleroSchedule.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/metabase/dependent/MetabaseVeleroSchedule.kt
@@ -1,8 +1,9 @@
 package eu.glasskube.operator.apps.metabase.dependent
 
 import eu.glasskube.operator.apps.metabase.Metabase
+import eu.glasskube.operator.apps.metabase.MetabaseReconciler
 import eu.glasskube.operator.generic.dependent.backups.DependentVeleroSchedule
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 
-@KubernetesDependent
+@KubernetesDependent(labelSelector = MetabaseReconciler.SELECTOR)
 class MetabaseVeleroSchedule : DependentVeleroSchedule<Metabase>()

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/nextcloud/NextcloudReconciler.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/nextcloud/NextcloudReconciler.kt
@@ -138,19 +138,15 @@ class NextcloudReconciler(webhookService: WebhookService) :
 
     override fun prepareEventSources(context: EventSourceContext<Nextcloud>) = with(context) {
         mutableMapOf(
-            DEPLOYMENT_EVENT_SOURCE to informerEventSource<Deployment>(),
-            SERVICE_EVENT_SOURCE to informerEventSource<Service>(),
-            CRON_JOB_EVENT_SOURCE to informerEventSource<CronJob>()
+            DEPLOYMENT_EVENT_SOURCE to informerEventSource<Deployment>(COMMON_SELECTOR),
+            SERVICE_EVENT_SOURCE to informerEventSource<Service>(COMMON_SELECTOR),
+            CRON_JOB_EVENT_SOURCE to informerEventSource<CronJob>(SELECTOR)
         )
     }
 
     companion object {
-        const val SELECTOR =
-            "${Labels.MANAGED_BY_GLASSKUBE},${Labels.PART_OF}=${Nextcloud.APP_NAME},${Labels.NAME}=${Nextcloud.APP_NAME}"
-        const val OFFICE_SELECTOR =
-            "${Labels.MANAGED_BY_GLASSKUBE},${Labels.PART_OF}=${Nextcloud.APP_NAME},${Labels.NAME}=${Nextcloud.OFFICE_NAME}"
-        const val REDIS_SELECTOR =
-            "${Labels.MANAGED_BY_GLASSKUBE},${Labels.PART_OF}=${Nextcloud.APP_NAME},${Labels.NAME}=${Nextcloud.Redis.NAME}"
+        private const val COMMON_SELECTOR = "${Labels.MANAGED_BY_GLASSKUBE},${Labels.PART_OF}=${Nextcloud.APP_NAME}"
+        const val SELECTOR = "$COMMON_SELECTOR,${Labels.NAME}=${Nextcloud.APP_NAME}"
 
         internal const val SERVICE_EVENT_SOURCE = "NextcloudServiceEventSource"
         internal const val DEPLOYMENT_EVENT_SOURCE = "NextcloudDeploymentEventSource"

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/nextcloud/dependent/NextcloudConfigMap.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/nextcloud/dependent/NextcloudConfigMap.kt
@@ -6,6 +6,7 @@ import eu.glasskube.kubernetes.api.model.namespace
 import eu.glasskube.operator.api.reconciler.getSecondaryResource
 import eu.glasskube.operator.apps.nextcloud.Nextcloud
 import eu.glasskube.operator.apps.nextcloud.NextcloudInstallConfig
+import eu.glasskube.operator.apps.nextcloud.NextcloudReconciler
 import eu.glasskube.operator.apps.nextcloud.NextcloudSpec
 import eu.glasskube.operator.apps.nextcloud.configName
 import eu.glasskube.operator.apps.nextcloud.resourceLabels
@@ -16,7 +17,7 @@ import io.javaoperatorsdk.operator.api.reconciler.Context
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUDKubernetesDependentResource
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 
-@KubernetesDependent
+@KubernetesDependent(labelSelector = NextcloudReconciler.SELECTOR)
 class NextcloudConfigMap : CRUDKubernetesDependentResource<ConfigMap, Nextcloud>(ConfigMap::class.java) {
     override fun desired(primary: Nextcloud, context: Context<Nextcloud>) = configMap {
         metadata {

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/nextcloud/dependent/NextcloudOfficeDeployment.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/nextcloud/dependent/NextcloudOfficeDeployment.kt
@@ -14,7 +14,6 @@ import eu.glasskube.kubernetes.api.model.namespace
 import eu.glasskube.kubernetes.api.model.resources
 import eu.glasskube.kubernetes.api.model.spec
 import eu.glasskube.operator.apps.nextcloud.Nextcloud
-import eu.glasskube.operator.apps.nextcloud.NextcloudReconciler
 import eu.glasskube.operator.apps.nextcloud.image
 import eu.glasskube.operator.apps.nextcloud.officeName
 import eu.glasskube.operator.apps.nextcloud.officeResourceLabelSelector
@@ -27,10 +26,7 @@ import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUDKubernete
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 import io.javaoperatorsdk.operator.processing.event.ResourceID
 
-@KubernetesDependent(
-    labelSelector = NextcloudReconciler.OFFICE_SELECTOR,
-    resourceDiscriminator = NextcloudOfficeDeployment.Discriminator::class
-)
+@KubernetesDependent(resourceDiscriminator = NextcloudOfficeDeployment.Discriminator::class)
 class NextcloudOfficeDeployment : CRUDKubernetesDependentResource<Deployment, Nextcloud>(Deployment::class.java) {
 
     class ReconcilePrecondition : IsOfficeEnabledPrecondition<Deployment>()

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/nextcloud/dependent/NextcloudOfficeService.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/nextcloud/dependent/NextcloudOfficeService.kt
@@ -6,7 +6,6 @@ import eu.glasskube.kubernetes.api.model.service
 import eu.glasskube.kubernetes.api.model.servicePort
 import eu.glasskube.kubernetes.api.model.spec
 import eu.glasskube.operator.apps.nextcloud.Nextcloud
-import eu.glasskube.operator.apps.nextcloud.NextcloudReconciler
 import eu.glasskube.operator.apps.nextcloud.officeName
 import eu.glasskube.operator.apps.nextcloud.officeResourceLabelSelector
 import eu.glasskube.operator.apps.nextcloud.officeResourceLabels
@@ -17,10 +16,7 @@ import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUDKubernete
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 import io.javaoperatorsdk.operator.processing.event.ResourceID
 
-@KubernetesDependent(
-    labelSelector = NextcloudReconciler.OFFICE_SELECTOR,
-    resourceDiscriminator = NextcloudOfficeService.Discriminator::class
-)
+@KubernetesDependent(resourceDiscriminator = NextcloudOfficeService.Discriminator::class)
 class NextcloudOfficeService : CRUDKubernetesDependentResource<Service, Nextcloud>(Service::class.java) {
 
     class ReconcilePrecondition : IsOfficeEnabledPrecondition<Service>()

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/nextcloud/dependent/NextcloudRedisDeployment.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/nextcloud/dependent/NextcloudRedisDeployment.kt
@@ -3,17 +3,13 @@ package eu.glasskube.operator.apps.nextcloud.dependent
 import eu.glasskube.kubernetes.api.model.namespace
 import eu.glasskube.operator.apps.nextcloud.Nextcloud
 import eu.glasskube.operator.apps.nextcloud.Nextcloud.Redis.redisName
-import eu.glasskube.operator.apps.nextcloud.NextcloudReconciler
 import eu.glasskube.operator.generic.dependent.redis.RedisDeployment
 import io.fabric8.kubernetes.api.model.apps.Deployment
 import io.javaoperatorsdk.operator.api.reconciler.ResourceIDMatcherDiscriminator
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 import io.javaoperatorsdk.operator.processing.event.ResourceID
 
-@KubernetesDependent(
-    labelSelector = NextcloudReconciler.REDIS_SELECTOR,
-    resourceDiscriminator = NextcloudRedisDeployment.Discriminator::class
-)
+@KubernetesDependent(resourceDiscriminator = NextcloudRedisDeployment.Discriminator::class)
 class NextcloudRedisDeployment : RedisDeployment<Nextcloud>() {
     internal class Discriminator : ResourceIDMatcherDiscriminator<Deployment, Nextcloud>({
         ResourceID(it.redisName, it.namespace)

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/nextcloud/dependent/NextcloudRedisService.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/nextcloud/dependent/NextcloudRedisService.kt
@@ -3,17 +3,13 @@ package eu.glasskube.operator.apps.nextcloud.dependent
 import eu.glasskube.kubernetes.api.model.namespace
 import eu.glasskube.operator.apps.nextcloud.Nextcloud
 import eu.glasskube.operator.apps.nextcloud.Nextcloud.Redis.redisName
-import eu.glasskube.operator.apps.nextcloud.NextcloudReconciler
 import eu.glasskube.operator.generic.dependent.redis.RedisService
 import io.fabric8.kubernetes.api.model.Service
 import io.javaoperatorsdk.operator.api.reconciler.ResourceIDMatcherDiscriminator
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 import io.javaoperatorsdk.operator.processing.event.ResourceID
 
-@KubernetesDependent(
-    labelSelector = NextcloudReconciler.REDIS_SELECTOR,
-    resourceDiscriminator = NextcloudRedisDeployment.Discriminator::class
-)
+@KubernetesDependent(resourceDiscriminator = NextcloudRedisDeployment.Discriminator::class)
 class NextcloudRedisService : RedisService<Nextcloud>() {
     internal class Discriminator : ResourceIDMatcherDiscriminator<Service, Nextcloud>({
         ResourceID(it.redisName, it.namespace)

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/nextcloud/dependent/NextcloudVeleroBackupStorageLocation.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/nextcloud/dependent/NextcloudVeleroBackupStorageLocation.kt
@@ -1,8 +1,9 @@
 package eu.glasskube.operator.apps.nextcloud.dependent
 
 import eu.glasskube.operator.apps.nextcloud.Nextcloud
+import eu.glasskube.operator.apps.nextcloud.NextcloudReconciler
 import eu.glasskube.operator.generic.dependent.backups.DependentVeleroBackupStorageLocation
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 
-@KubernetesDependent
+@KubernetesDependent(labelSelector = NextcloudReconciler.SELECTOR)
 class NextcloudVeleroBackupStorageLocation : DependentVeleroBackupStorageLocation<Nextcloud>()

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/nextcloud/dependent/NextcloudVeleroSchedule.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/nextcloud/dependent/NextcloudVeleroSchedule.kt
@@ -1,8 +1,9 @@
 package eu.glasskube.operator.apps.nextcloud.dependent
 
 import eu.glasskube.operator.apps.nextcloud.Nextcloud
+import eu.glasskube.operator.apps.nextcloud.NextcloudReconciler
 import eu.glasskube.operator.generic.dependent.backups.DependentVeleroSchedule
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 
-@KubernetesDependent
+@KubernetesDependent(labelSelector = NextcloudReconciler.SELECTOR)
 class NextcloudVeleroSchedule : DependentVeleroSchedule<Nextcloud>()

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/nextcloud/dependent/NextcloudVeleroSecret.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/nextcloud/dependent/NextcloudVeleroSecret.kt
@@ -1,12 +1,13 @@
 package eu.glasskube.operator.apps.nextcloud.dependent
 
 import eu.glasskube.operator.apps.nextcloud.Nextcloud
+import eu.glasskube.operator.apps.nextcloud.NextcloudReconciler
 import eu.glasskube.operator.generic.dependent.backups.BackupSpecNotNullCondition
 import eu.glasskube.operator.generic.dependent.backups.DependentVeleroSecret
 import io.fabric8.kubernetes.api.model.Secret
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 
-@KubernetesDependent
+@KubernetesDependent(labelSelector = NextcloudReconciler.SELECTOR)
 class NextcloudVeleroSecret : DependentVeleroSecret<Nextcloud>() {
     internal class ReconcilePrecondition : BackupSpecNotNullCondition<Secret, Nextcloud>()
 }

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/odoo/OdooReconciler.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/odoo/OdooReconciler.kt
@@ -95,7 +95,7 @@ class OdooReconciler(webhookService: WebhookService) :
 
     override fun prepareEventSources(context: EventSourceContext<Odoo>) = with(context) {
         mutableMapOf(
-            SECRET_EVENT_SOURCE to informerEventSource<Secret> {
+            SECRET_EVENT_SOURCE to informerEventSource<Secret>(SELECTOR) {
                 withSecondaryToPrimaryMapper(
                     CompositeSecondaryToPrimaryMapper(
                         Mappers.fromOwnerReference(),

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/odoo/dependent/OdooVeleroBackupStorageLocation.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/odoo/dependent/OdooVeleroBackupStorageLocation.kt
@@ -1,8 +1,9 @@
 package eu.glasskube.operator.apps.odoo.dependent
 
 import eu.glasskube.operator.apps.odoo.Odoo
+import eu.glasskube.operator.apps.odoo.OdooReconciler
 import eu.glasskube.operator.generic.dependent.backups.DependentVeleroBackupStorageLocation
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 
-@KubernetesDependent
+@KubernetesDependent(labelSelector = OdooReconciler.SELECTOR)
 class OdooVeleroBackupStorageLocation : DependentVeleroBackupStorageLocation<Odoo>()

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/odoo/dependent/OdooVeleroSchedule.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/odoo/dependent/OdooVeleroSchedule.kt
@@ -1,8 +1,9 @@
 package eu.glasskube.operator.apps.odoo.dependent
 
 import eu.glasskube.operator.apps.odoo.Odoo
+import eu.glasskube.operator.apps.odoo.OdooReconciler
 import eu.glasskube.operator.generic.dependent.backups.DependentVeleroSchedule
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 
-@KubernetesDependent
+@KubernetesDependent(labelSelector = OdooReconciler.SELECTOR)
 class OdooVeleroSchedule : DependentVeleroSchedule<Odoo>()

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/plane/Plane.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/plane/Plane.kt
@@ -26,7 +26,7 @@ class Plane :
     ResourceWithCloudStorage,
     ResourceWithDatabaseSpec<PostgresDatabaseSpec> {
     object Redis : RedisNameMapper<Plane>() {
-        private const val NAME = "redis"
+        internal const val NAME = "redis"
         private const val VERSION = "7.2.1"
 
         override fun getName(primary: Plane) = "${primary.genericResourceName}-$NAME"

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/plane/PlaneReconciler.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/plane/PlaneReconciler.kt
@@ -3,6 +3,7 @@ package eu.glasskube.operator.apps.plane
 import eu.glasskube.kubernetes.api.model.loggingId
 import eu.glasskube.kubernetes.api.model.namespace
 import eu.glasskube.kubernetes.client.patchOrUpdateStatus
+import eu.glasskube.operator.Labels
 import eu.glasskube.operator.api.reconciler.getSecondaryResource
 import eu.glasskube.operator.api.reconciler.informerEventSource
 import eu.glasskube.operator.apps.plane.dependent.PlaneApiConfigMap
@@ -226,10 +227,10 @@ class PlaneReconciler(webhookService: WebhookService) :
 
     override fun prepareEventSources(context: EventSourceContext<Plane>) = with(context) {
         mutableMapOf<String, EventSource>(
-            SERVICE_EVENT_SOURCE to informerEventSource<Service>(),
-            DEPLOYMENT_EVENT_SOURCE to informerEventSource<Deployment>(),
-            CONFIGMAP_EVENT_SOURCE to informerEventSource<ConfigMap>(),
-            SECRET_EVENT_SOURCE to informerEventSource<Secret> {
+            SERVICE_EVENT_SOURCE to informerEventSource<Service>(SELECTOR),
+            DEPLOYMENT_EVENT_SOURCE to informerEventSource<Deployment>(SELECTOR),
+            CONFIGMAP_EVENT_SOURCE to informerEventSource<ConfigMap>(SELECTOR),
+            SECRET_EVENT_SOURCE to informerEventSource<Secret>(SELECTOR) {
                 withSecondaryToPrimaryMapper(
                     CompositeSecondaryToPrimaryMapper(
                         Mappers.fromOwnerReference(),
@@ -241,6 +242,7 @@ class PlaneReconciler(webhookService: WebhookService) :
     }
 
     companion object {
+        internal const val SELECTOR = "${Labels.MANAGED_BY_GLASSKUBE},${Labels.NAME}=${Plane.APP_NAME}"
         internal const val SERVICE_EVENT_SOURCE = "PlaneServiceEventSource"
         internal const val DEPLOYMENT_EVENT_SOURCE = "PlaneDeploymentEventSource"
         internal const val CONFIGMAP_EVENT_SOURCE = "PlaneConfigMapEventSource"

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/plane/dependent/PlaneCloudStorageBackupCronJob.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/plane/dependent/PlaneCloudStorageBackupCronJob.kt
@@ -1,10 +1,11 @@
 package eu.glasskube.operator.apps.plane.dependent
 
 import eu.glasskube.operator.apps.plane.Plane
+import eu.glasskube.operator.apps.plane.PlaneReconciler
 import eu.glasskube.operator.generic.dependent.backups.DependentCloudStorageBackupCronJob
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 
-@KubernetesDependent
+@KubernetesDependent(labelSelector = PlaneReconciler.SELECTOR)
 class PlaneCloudStorageBackupCronJob : DependentCloudStorageBackupCronJob<Plane>() {
     internal class ReconcilePrecondition : DependentCloudStorageBackupCronJob.ReconcilePrecondition<Plane>()
 }

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/plane/dependent/PlaneIngress.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/plane/dependent/PlaneIngress.kt
@@ -9,6 +9,7 @@ import eu.glasskube.kubernetes.api.model.extensions.spec
 import eu.glasskube.kubernetes.api.model.metadata
 import eu.glasskube.kubernetes.api.model.namespace
 import eu.glasskube.operator.apps.plane.Plane
+import eu.glasskube.operator.apps.plane.PlaneReconciler
 import eu.glasskube.operator.apps.plane.apiResourceName
 import eu.glasskube.operator.apps.plane.frontendResourceName
 import eu.glasskube.operator.apps.plane.genericResourceLabels
@@ -21,7 +22,7 @@ import io.fabric8.kubernetes.api.model.networking.v1.IngressTLS
 import io.javaoperatorsdk.operator.api.reconciler.Context
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 
-@KubernetesDependent
+@KubernetesDependent(labelSelector = PlaneReconciler.SELECTOR)
 class PlaneIngress(configService: ConfigService) : DependentIngress<Plane>(configService) {
     override fun desired(primary: Plane, context: Context<Plane>) = ingress {
         metadata {

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/plane/dependent/PlanePostgresBackup.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/plane/dependent/PlanePostgresBackup.kt
@@ -1,8 +1,9 @@
 package eu.glasskube.operator.apps.plane.dependent
 
 import eu.glasskube.operator.apps.plane.Plane
+import eu.glasskube.operator.apps.plane.PlaneReconciler
 import eu.glasskube.operator.generic.dependent.postgres.DependentPostgresScheduledBackup
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 
-@KubernetesDependent
+@KubernetesDependent(labelSelector = PlaneReconciler.SELECTOR)
 class PlanePostgresBackup : DependentPostgresScheduledBackup<Plane>(Plane.Postgres)

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/plane/dependent/PlanePostgresCluster.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/plane/dependent/PlanePostgresCluster.kt
@@ -1,12 +1,13 @@
 package eu.glasskube.operator.apps.plane.dependent
 
 import eu.glasskube.operator.apps.plane.Plane
+import eu.glasskube.operator.apps.plane.PlaneReconciler
 import eu.glasskube.operator.config.ConfigService
 import eu.glasskube.operator.generic.condition.PostgresReadyCondition
 import eu.glasskube.operator.generic.dependent.postgres.DependentPostgresCluster
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 
-@KubernetesDependent
+@KubernetesDependent(labelSelector = PlaneReconciler.SELECTOR)
 class PlanePostgresCluster(configService: ConfigService) :
     DependentPostgresCluster<Plane>(Plane.Postgres, configService) {
 

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/plane/dependent/PlanePostgresMinioBucket.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/plane/dependent/PlanePostgresMinioBucket.kt
@@ -5,6 +5,7 @@ import eu.glasskube.kubernetes.api.model.namespace
 import eu.glasskube.operator.apps.plane.Plane
 import eu.glasskube.operator.apps.plane.Plane.Postgres.postgresClusterLabels
 import eu.glasskube.operator.apps.plane.Plane.Postgres.postgresClusterName
+import eu.glasskube.operator.apps.plane.PlaneReconciler
 import eu.glasskube.operator.generic.dependent.postgres.PostgresWithoutBackupsSpecCondition
 import eu.glasskube.operator.infra.minio.MinioBucket
 import eu.glasskube.operator.infra.minio.MinioBucketSpec
@@ -13,7 +14,7 @@ import io.javaoperatorsdk.operator.api.reconciler.Context
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUDKubernetesDependentResource
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 
-@KubernetesDependent
+@KubernetesDependent(labelSelector = PlaneReconciler.SELECTOR)
 class PlanePostgresMinioBucket : CRUDKubernetesDependentResource<MinioBucket, Plane>(MinioBucket::class.java) {
     internal class ReconcilePrecondition : PostgresWithoutBackupsSpecCondition<MinioBucket, Plane>()
 

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/plane/dependent/PlaneVeleroBackupStorageLocation.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/plane/dependent/PlaneVeleroBackupStorageLocation.kt
@@ -1,8 +1,9 @@
 package eu.glasskube.operator.apps.plane.dependent
 
 import eu.glasskube.operator.apps.plane.Plane
+import eu.glasskube.operator.apps.plane.PlaneReconciler
 import eu.glasskube.operator.generic.dependent.backups.DependentVeleroBackupStorageLocation
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 
-@KubernetesDependent
+@KubernetesDependent(labelSelector = PlaneReconciler.SELECTOR)
 class PlaneVeleroBackupStorageLocation : DependentVeleroBackupStorageLocation<Plane>()

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/plane/dependent/PlaneVeleroSchedule.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/plane/dependent/PlaneVeleroSchedule.kt
@@ -1,8 +1,9 @@
 package eu.glasskube.operator.apps.plane.dependent
 
 import eu.glasskube.operator.apps.plane.Plane
+import eu.glasskube.operator.apps.plane.PlaneReconciler
 import eu.glasskube.operator.generic.dependent.backups.DependentVeleroSchedule
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 
-@KubernetesDependent
+@KubernetesDependent(labelSelector = PlaneReconciler.SELECTOR)
 class PlaneVeleroSchedule : DependentVeleroSchedule<Plane>()

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/vault/VaultReconciler.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/vault/VaultReconciler.kt
@@ -121,8 +121,8 @@ class VaultReconciler(webhookService: WebhookService) :
 
     override fun prepareEventSources(context: EventSourceContext<Vault>) = with(context) {
         mutableMapOf(
-            SERVICE_EVENT_SOURCE to informerEventSource<Service>(),
-            CLUSTER_ROLE_BINDING_EVENT_SOURCE to informerEventSource<ClusterRoleBinding> {
+            SERVICE_EVENT_SOURCE to informerEventSource<Service>(SELECTOR),
+            CLUSTER_ROLE_BINDING_EVENT_SOURCE to informerEventSource<ClusterRoleBinding>(SELECTOR) {
                 withSecondaryToPrimaryMapper(Mappers.fromDefaultAnnotations())
             }
         )

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/vault/dependent/VaultStatefulSet.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/vault/dependent/VaultStatefulSet.kt
@@ -23,6 +23,7 @@ import eu.glasskube.operator.apps.vault.Vault
 import eu.glasskube.operator.apps.vault.Vault.Postgres.postgresDatabaseName
 import eu.glasskube.operator.apps.vault.Vault.Postgres.postgresHostName
 import eu.glasskube.operator.apps.vault.Vault.Postgres.postgresSecretName
+import eu.glasskube.operator.apps.vault.VaultReconciler
 import eu.glasskube.operator.apps.vault.appImage
 import eu.glasskube.operator.apps.vault.genericResourceName
 import eu.glasskube.operator.apps.vault.headlessServiceName
@@ -36,7 +37,9 @@ import io.fabric8.kubernetes.api.model.VolumeMount
 import io.fabric8.kubernetes.api.model.apps.StatefulSet
 import io.javaoperatorsdk.operator.api.reconciler.Context
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUDKubernetesDependentResource
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 
+@KubernetesDependent(labelSelector = VaultReconciler.SELECTOR)
 class VaultStatefulSet(private val configService: ConfigService) :
     CRUDKubernetesDependentResource<StatefulSet, Vault>(StatefulSet::class.java) {
 

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/vault/dependent/VaultVeleroBackupStorageLocation.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/vault/dependent/VaultVeleroBackupStorageLocation.kt
@@ -1,8 +1,9 @@
 package eu.glasskube.operator.apps.vault.dependent
 
 import eu.glasskube.operator.apps.vault.Vault
+import eu.glasskube.operator.apps.vault.VaultReconciler
 import eu.glasskube.operator.generic.dependent.backups.DependentVeleroBackupStorageLocation
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 
-@KubernetesDependent
+@KubernetesDependent(labelSelector = VaultReconciler.SELECTOR)
 class VaultVeleroBackupStorageLocation : DependentVeleroBackupStorageLocation<Vault>()

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/vault/dependent/VaultVeleroSchedule.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/vault/dependent/VaultVeleroSchedule.kt
@@ -1,8 +1,9 @@
 package eu.glasskube.operator.apps.vault.dependent
 
 import eu.glasskube.operator.apps.vault.Vault
+import eu.glasskube.operator.apps.vault.VaultReconciler
 import eu.glasskube.operator.generic.dependent.backups.DependentVeleroSchedule
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 
-@KubernetesDependent
+@KubernetesDependent(labelSelector = VaultReconciler.SELECTOR)
 class VaultVeleroSchedule : DependentVeleroSchedule<Vault>()

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/vault/dependent/VaultVeleroSecret.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/vault/dependent/VaultVeleroSecret.kt
@@ -1,12 +1,13 @@
 package eu.glasskube.operator.apps.vault.dependent
 
 import eu.glasskube.operator.apps.vault.Vault
+import eu.glasskube.operator.apps.vault.VaultReconciler
 import eu.glasskube.operator.generic.dependent.backups.BackupSpecNotNullCondition
 import eu.glasskube.operator.generic.dependent.backups.DependentVeleroSecret
 import io.fabric8.kubernetes.api.model.Secret
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent
 
-@KubernetesDependent
+@KubernetesDependent(labelSelector = VaultReconciler.SELECTOR)
 class VaultVeleroSecret : DependentVeleroSecret<Vault>() {
     internal class ReconcilePrecondition : BackupSpecNotNullCondition<Secret, Vault>()
 }


### PR DESCRIPTION
In addition to adding label selectors to all explicitly created event sources, all `KubernetesDependentResources` now have at least a label selector OR resource discriminator.

When creating an informer event source using the `informerEventSource` function we now require a label selector to prevent accidentally creating an `InformerEventSource` without one. If a use case for such an event source ever arises, I propose that we create a separate function for this to make the lack of a label selector more obvious.

With this change, the operator can be started in Kubernetes clusters managed by OVH reliably again. I was able to run it 10+ times without encountering any errors. Also, startup time is greatly reduced (on my machine from 9-12s to about 4.5s).