### PR TITLE
fix(Nextcloud): add backofflimit, to stop pod spamming

### DIFF
--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/nextcloud/dependent/NextcloudCronJob.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/nextcloud/dependent/NextcloudCronJob.kt
@@ -48,6 +48,7 @@ class NextcloudCronJob : CRUDKubernetesDependentResource<CronJob, Nextcloud>(Cro
             schedule = "*/5 * * * *"
             jobTemplate {
                 spec {
+                    backoffLimit = 1
                     template {
                         spec {
                             restartPolicy = "Never"


### PR DESCRIPTION
If a pod failed it would have restarted immediately which resulted in a DOS of the postgres connections.
