### PR TITLE
feat(nextcloud): support host change

### DIFF
--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/nextcloud/dependent/NextcloudConfigMap.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/nextcloud/dependent/NextcloudConfigMap.kt
@@ -61,6 +61,10 @@ class NextcloudConfigMap : CRUDKubernetesDependentResource<ConfigMap, Nextcloud>
                         "172.16.0.0/12",
                         "192.168.0.0/16"
                     ),
+                    "trusted_domains" to listOf(
+                        "localhost",
+                        primary.spec.host
+                    ),
                     "log_type" to "errorlog",
                     "log_level" to 2,
                     *primary.spec.apps.oidc?.let {


### PR DESCRIPTION
nextcloud enforces that requests come from a trusted source. this trusted source is now set from the spec  and gets reconfigured on every new deployment