### PR TITLE
docs: Extend CRD reference in Keycloak documentation with custom image functionality

### DIFF
--- a/docs/docs/03_crd-reference/keycloak.md
+++ b/docs/docs/03_crd-reference/keycloak.md
@@ -16,9 +16,14 @@ kind: Keycloak
 metadata:
   name: keycloak
 spec:
+  version: "21.1.2"
   host: keycloak.mycompany.eu
   management:
     enabled: true
+  image: "quay.io/keycloak/keycloak:21.1.2"
+  imagePullSecrets:
+    - name: "secret-name"
+
 ```
 
 ## Spec
@@ -30,7 +35,8 @@ spec:
 | management | [ManagementSpec](#management)                                                                          |            | Configuration of the keycloak management UI                                    |
 | resources  | [ResourceRequirements](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |            |                                                                                |
 | database   | [PostgresDatabaseSpec](./../common/postgres)?                                                          |            |                                                                                |
-
+| image      | String                                                                                                 |            | The Docker image to be used for Keycloak deployment.                           |
+| imagePullSecrets| List of [LocalObjectReference](https://github.com/kubernetes-client/java/blob/master/kubernetes/docs/V1LocalObjectReference.md)| | Secrets to pull private Docker images.                       |
 ### ManagementSpec {#management}
 
 | Name    | Type    | Default |                                                          |


### PR DESCRIPTION
This pull request enhances the documentation for the Keycloak Custom Resource Definition (CRD) by incorporating details about custom image functionality. By doing so, it provides users with clear instructions on how to utilize custom Docker images effectively within Keycloak deployments. This documentation update addresses the need for comprehensive guidance, ensuring users can seamlessly integrate custom images into their Keycloak instances, thereby enhancing flexibility and customization options for Keycloak deployments.

fixes #462 