### PR TITLE
Feat(Gitlab): add storage size to spec gitlab-data

### DIFF
--- a/deploy/crd/gitlabs.glasskube.eu-v1.yml
+++ b/deploy/crd/gitlabs.glasskube.eu-v1.yml
@@ -254,6 +254,17 @@ spec:
                 type: boolean
               sshHost:
                 type: string
+              storage:
+                nullable: true
+                properties:
+                  size:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    x-kubernetes-int-or-string: true
+                  storageClassName:
+                    type: string
+                type: object
               version:
                 pattern: \d+\.\d+\.\d+
                 type: string

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/gitlab/GitlabSpec.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/gitlab/GitlabSpec.kt
@@ -34,8 +34,15 @@ data class GitlabSpec(
     @field:Pattern(SEMVER)
     val version: String = "16.2.5",
     @field:Nullable
+    val storage: StorageSpec?,
+    @field:Nullable
     override val database: PostgresDatabaseSpec = PostgresDatabaseSpec(),
     override val backups: BackupSpec?
 ) : HasBackupSpec, HasCloudStorageSpec, HasDatabaseSpec<PostgresDatabaseSpec> {
     override val cloudStorage get() = registry?.storage?.s3
 }
+
+data class StorageSpec(
+    val size: Quantity?,
+    val storageClassName: String?
+)

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/gitlab/dependent/GitlabVolume.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/gitlab/dependent/GitlabVolume.kt
@@ -25,9 +25,10 @@ class GitlabVolume : CRUDKubernetesDependentResource<PersistentVolumeClaim, Gitl
         spec {
             resources {
                 requests = mapOf(
-                    "storage" to Quantity("20", "Gi")
+                    "storage" to (primary.spec.storage?.size ?: Quantity("20", "Gi"))
                 )
             }
+            storageClassName = primary.spec.storage?.storageClassName
             accessModes = listOf("ReadWriteOnce")
         }
     }


### PR DESCRIPTION
initial changes trying to add changes for  #529 


I did try to build and follow the [contributing guide](https://github.com/glasskube/operator/blob/main/CONTRIBUTING.md)


I did manage to build succesfully I think.

```
./gradlew loadImage  

> Task :operator:kaptKotlin
Annotation processors discovery from compile classpath is deprecated.
Set 'kapt.include.compile.classpath=false' to disable discovery.
Run the build with '--info' for more details.
12:28:29.176 [WorkerExecutor Queue] INFO io.fabric8.crd.generator.CRDGenerator -- Generating 'giteas.glasskube.eu' version 'v1alpha1' with eu.glasskube.operator.apps.gitea.Gitea (spec: eu.glasskube.operator.apps.gitea.GiteaSpec / status eu.glasskube.operator.apps.gitea.GiteaStatus)...
12:28:29.403 [WorkerExecutor Queue] INFO io.fabric8.crd.generator.CRDGenerator -- Generating 'glitchtips.glasskube.eu' version 'v1alpha1' with eu.glasskube.operator.apps.glitchtip.Glitchtip (spec: eu.glasskube.operator.apps.glitchtip.GlitchtipSpec / status eu.glasskube.operator.apps.glitchtip.GlitchtipStatus)...
12:28:29.507 [WorkerExecutor Queue] INFO io.fabric8.crd.generator.CRDGenerator -- Generating 'clusters.postgresql.cnpg.io' version 'v1' with eu.glasskube.operator.infra.postgres.PostgresCluster (spec: eu.glasskube.operator.infra.postgres.ClusterSpec / status eu.glasskube.operator.infra.postgres.ClusterStatus)...
12:28:29.808 [WorkerExecutor Queue] INFO io.fabric8.crd.generator.CRDGenerator -- Generating 'mariadbs.mariadb.mmontes.io' version 'v1alpha1' with eu.glasskube.operator.infra.mariadb.MariaDB (spec: eu.glasskube.operator.infra.mariadb.MariaDBSpec / status eu.glasskube.operator.infra.mariadb.MariaDBStatus)...
12:28:29.962 [WorkerExecutor Queue] INFO io.fabric8.crd.generator.CRDGenerator -- Generating 'miniobuckets.glasskube.eu' version 'v1alpha1' with eu.glasskube.operator.infra.minio.MinioBucket (spec: eu.glasskube.operator.infra.minio.MinioBucketSpec / status eu.glasskube.operator.infra.minio.MinioBucketStatus)...
12:28:29.973 [WorkerExecutor Queue] INFO io.fabric8.crd.generator.CRDGenerator -- Generating 'nextclouds.glasskube.eu' version 'v1alpha1' with eu.glasskube.operator.apps.nextcloud.Nextcloud (spec: eu.glasskube.operator.apps.nextcloud.NextcloudSpec / status eu.glasskube.operator.apps.nextcloud.NextcloudStatus)...
12:28:30.160 [WorkerExecutor Queue] INFO io.fabric8.crd.generator.CRDGenerator -- Generating 'gitlabs.glasskube.eu' version 'v1alpha1' with eu.glasskube.operator.apps.gitlab.Gitlab (spec: eu.glasskube.operator.apps.gitlab.GitlabSpec / status eu.glasskube.operator.apps.gitlab.GitlabStatus)...
12:28:30.305 [WorkerExecutor Queue] INFO io.fabric8.crd.generator.CRDGenerator -- Generating 'vaults.glasskube.eu' version 'v1alpha1' with eu.glasskube.operator.apps.vault.Vault (spec: eu.glasskube.operator.apps.vault.VaultSpec / status eu.glasskube.operator.apps.vault.VaultStatus)...
12:28:30.417 [WorkerExecutor Queue] INFO io.fabric8.crd.generator.CRDGenerator -- Generating 'matomos.glasskube.eu' version 'v1alpha1' with eu.glasskube.operator.apps.matomo.Matomo (spec: eu.glasskube.operator.apps.matomo.MatomoSpec / status eu.glasskube.operator.apps.matomo.MatomoStatus)...
12:28:30.450 [WorkerExecutor Queue] INFO io.fabric8.crd.generator.CRDGenerator -- Generating 'scheduledbackups.postgresql.cnpg.io' version 'v1' with eu.glasskube.operator.infra.postgres.ScheduledBackup (spec: eu.glasskube.operator.infra.postgres.ScheduledBackupSpec / status eu.glasskube.operator.infra.postgres.ScheduledBackupStatus)...
12:28:30.468 [WorkerExecutor Queue] INFO io.fabric8.crd.generator.CRDGenerator -- Generating 'schedules.velero.io' version 'v1' with eu.glasskube.operator.infra.velero.VeleroSchedule (spec: eu.glasskube.operator.infra.velero.VeleroSchedule.Spec / status eu.glasskube.operator.infra.velero.VeleroSchedule.Status)...
12:28:30.486 [WorkerExecutor Queue] INFO io.fabric8.crd.generator.CRDGenerator -- Generating 'planes.glasskube.eu' version 'v1alpha1' with eu.glasskube.operator.apps.plane.Plane (spec: eu.glasskube.operator.apps.plane.PlaneSpec / status eu.glasskube.operator.apps.plane.PlaneStatus)...
12:28:30.683 [WorkerExecutor Queue] INFO io.fabric8.crd.generator.CRDGenerator -- Generating 'metabases.glasskube.eu' version 'v1alpha1' with eu.glasskube.operator.apps.metabase.Metabase (spec: eu.glasskube.operator.apps.metabase.MetabaseSpec / status eu.glasskube.operator.apps.metabase.MetabaseStatus)...
12:28:30.801 [WorkerExecutor Queue] INFO io.fabric8.crd.generator.CRDGenerator -- Generating 'servicemonitors.monitoring.coreos.com' version 'v1' with eu.glasskube.operator.infra.prometheus.servicemonitor.ServiceMonitor (spec: eu.glasskube.operator.infra.prometheus.servicemonitor.ServiceMonitorSpec / status java.lang.Object)...
12:28:30.811 [WorkerExecutor Queue] INFO io.fabric8.crd.generator.CRDGenerator -- Generating 'keycloaks.glasskube.eu' version 'v1alpha1' with eu.glasskube.operator.apps.keycloak.Keycloak (spec: eu.glasskube.operator.apps.keycloak.KeycloakSpec / status eu.glasskube.operator.apps.keycloak.KeycloakStatus)...
12:28:30.940 [WorkerExecutor Queue] INFO io.fabric8.crd.generator.CRDGenerator -- Generating 'odoos.glasskube.eu' version 'v1alpha1' with eu.glasskube.operator.apps.odoo.Odoo (spec: eu.glasskube.operator.apps.odoo.OdooSpec / status eu.glasskube.operator.apps.odoo.OdooStatus)...
12:28:31.027 [WorkerExecutor Queue] INFO io.fabric8.crd.generator.CRDGenerator -- Generating 'backupstoragelocations.velero.io' version 'v1' with eu.glasskube.operator.infra.velero.VeleroBackupStorageLocation (spec: eu.glasskube.operator.infra.velero.VeleroBackupStorageLocation.Spec / status eu.glasskube.operator.infra.velero.VeleroBackupStorageLocation.Status)...
12:28:31.190 [WorkerExecutor Queue] INFO io.fabric8.crd.generator.CRDGenerator -- Generating 'gitlabrunners.glasskube.eu' version 'v1alpha1' with eu.glasskube.operator.apps.gitlab.runner.GitlabRunner (spec: eu.glasskube.operator.apps.gitlab.runner.GitlabRunnerSpec / status eu.glasskube.operator.apps.gitlab.runner.GitlabRunnerStatus)...
Note: Generating CRD servicemonitors.monitoring.coreos.com:
Note:   - v1beta1 -> /home/jrab66/Documents/github/millicom/glasskube-operator/operator/build/tmp/kapt3/classes/main/META-INF/fabric8/servicemonitors.monitoring.coreos.com-v1beta1.yml
Note:   - v1 -> /home/jrab66/Documents/github/millicom/glasskube-operator/operator/build/tmp/kapt3/classes/main/META-INF/fabric8/servicemonitors.monitoring.coreos.com-v1.yml
Note: Generating CRD glitchtips.glasskube.eu:
Note:   - v1beta1 -> /home/jrab66/Documents/github/millicom/glasskube-operator/operator/build/tmp/kapt3/classes/main/META-INF/fabric8/glitchtips.glasskube.eu-v1beta1.yml
Note:   - v1 -> /home/jrab66/Documents/github/millicom/glasskube-operator/operator/build/tmp/kapt3/classes/main/META-INF/fabric8/glitchtips.glasskube.eu-v1.yml
Note: Generating CRD giteas.glasskube.eu:
Note:   - v1beta1 -> /home/jrab66/Documents/github/millicom/glasskube-operator/operator/build/tmp/kapt3/classes/main/META-INF/fabric8/giteas.glasskube.eu-v1beta1.yml
Note:   - v1 -> /home/jrab66/Documents/github/millicom/glasskube-operator/operator/build/tmp/kapt3/classes/main/META-INF/fabric8/giteas.glasskube.eu-v1.yml
Note: Generating CRD matomos.glasskube.eu:
Note:   - v1beta1 -> /home/jrab66/Documents/github/millicom/glasskube-operator/operator/build/tmp/kapt3/classes/main/META-INF/fabric8/matomos.glasskube.eu-v1beta1.yml
Note:   - v1 -> /home/jrab66/Documents/github/millicom/glasskube-operator/operator/build/tmp/kapt3/classes/main/META-INF/fabric8/matomos.glasskube.eu-v1.yml
Note: Generating CRD miniobuckets.glasskube.eu:
Note:   - v1beta1 -> /home/jrab66/Documents/github/millicom/glasskube-operator/operator/build/tmp/kapt3/classes/main/META-INF/fabric8/miniobuckets.glasskube.eu-v1beta1.yml
Note:   - v1 -> /home/jrab66/Documents/github/millicom/glasskube-operator/operator/build/tmp/kapt3/classes/main/META-INF/fabric8/miniobuckets.glasskube.eu-v1.yml
Note: Generating CRD clusters.postgresql.cnpg.io:
Note:   - v1beta1 -> /home/jrab66/Documents/github/millicom/glasskube-operator/operator/build/tmp/kapt3/classes/main/META-INF/fabric8/clusters.postgresql.cnpg.io-v1beta1.yml
Note:   - v1 -> /home/jrab66/Documents/github/millicom/glasskube-operator/operator/build/tmp/kapt3/classes/main/META-INF/fabric8/clusters.postgresql.cnpg.io-v1.yml
Note: Generating CRD schedules.velero.io:
Note:   - v1beta1 -> /home/jrab66/Documents/github/millicom/glasskube-operator/operator/build/tmp/kapt3/classes/main/META-INF/fabric8/schedules.velero.io-v1beta1.yml
Note:   - v1 -> /home/jrab66/Documents/github/millicom/glasskube-operator/operator/build/tmp/kapt3/classes/main/META-INF/fabric8/schedules.velero.io-v1.yml
Note: Generating CRD odoos.glasskube.eu:
Note:   - v1beta1 -> /home/jrab66/Documents/github/millicom/glasskube-operator/operator/build/tmp/kapt3/classes/main/META-INF/fabric8/odoos.glasskube.eu-v1beta1.yml
Note:   - v1 -> /home/jrab66/Documents/github/millicom/glasskube-operator/operator/build/tmp/kapt3/classes/main/META-INF/fabric8/odoos.glasskube.eu-v1.yml
Note: Generating CRD metabases.glasskube.eu:
Note:   - v1beta1 -> /home/jrab66/Documents/github/millicom/glasskube-operator/operator/build/tmp/kapt3/classes/main/META-INF/fabric8/metabases.glasskube.eu-v1beta1.yml
Note:   - v1 -> /home/jrab66/Documents/github/millicom/glasskube-operator/operator/build/tmp/kapt3/classes/main/META-INF/fabric8/metabases.glasskube.eu-v1.yml
Note: Generating CRD mariadbs.mariadb.mmontes.io:
Note:   - v1beta1 -> /home/jrab66/Documents/github/millicom/glasskube-operator/operator/build/tmp/kapt3/classes/main/META-INF/fabric8/mariadbs.mariadb.mmontes.io-v1beta1.yml
Note:   - v1 -> /home/jrab66/Documents/github/millicom/glasskube-operator/operator/build/tmp/kapt3/classes/main/META-INF/fabric8/mariadbs.mariadb.mmontes.io-v1.yml
Note: Generating CRD planes.glasskube.eu:
Note:   - v1beta1 -> /home/jrab66/Documents/github/millicom/glasskube-operator/operator/build/tmp/kapt3/classes/main/META-INF/fabric8/planes.glasskube.eu-v1beta1.yml
Note:   - v1 -> /home/jrab66/Documents/github/millicom/glasskube-operator/operator/build/tmp/kapt3/classes/main/META-INF/fabric8/planes.glasskube.eu-v1.yml
Note: Generating CRD gitlabrunners.glasskube.eu:
Note:   - v1beta1 -> /home/jrab66/Documents/github/millicom/glasskube-operator/operator/build/tmp/kapt3/classes/main/META-INF/fabric8/gitlabrunners.glasskube.eu-v1beta1.yml
Note:   - v1 -> /home/jrab66/Documents/github/millicom/glasskube-operator/operator/build/tmp/kapt3/classes/main/META-INF/fabric8/gitlabrunners.glasskube.eu-v1.yml
Note: Generating CRD nextclouds.glasskube.eu:
Note:   - v1beta1 -> /home/jrab66/Documents/github/millicom/glasskube-operator/operator/build/tmp/kapt3/classes/main/META-INF/fabric8/nextclouds.glasskube.eu-v1beta1.yml
Note:   - v1 -> /home/jrab66/Documents/github/millicom/glasskube-operator/operator/build/tmp/kapt3/classes/main/META-INF/fabric8/nextclouds.glasskube.eu-v1.yml
Note: Generating CRD backupstoragelocations.velero.io:
Note:   - v1beta1 -> /home/jrab66/Documents/github/millicom/glasskube-operator/operator/build/tmp/kapt3/classes/main/META-INF/fabric8/backupstoragelocations.velero.io-v1beta1.yml
Note:   - v1 -> /home/jrab66/Documents/github/millicom/glasskube-operator/operator/build/tmp/kapt3/classes/main/META-INF/fabric8/backupstoragelocations.velero.io-v1.yml
Note: Generating CRD vaults.glasskube.eu:
Note:   - v1beta1 -> /home/jrab66/Documents/github/millicom/glasskube-operator/operator/build/tmp/kapt3/classes/main/META-INF/fabric8/vaults.glasskube.eu-v1beta1.yml
Note:   - v1 -> /home/jrab66/Documents/github/millicom/glasskube-operator/operator/build/tmp/kapt3/classes/main/META-INF/fabric8/vaults.glasskube.eu-v1.yml
Note: Generating CRD gitlabs.glasskube.eu:
Note:   - v1beta1 -> /home/jrab66/Documents/github/millicom/glasskube-operator/operator/build/tmp/kapt3/classes/main/META-INF/fabric8/gitlabs.glasskube.eu-v1beta1.yml
Note:   - v1 -> /home/jrab66/Documents/github/millicom/glasskube-operator/operator/build/tmp/kapt3/classes/main/META-INF/fabric8/gitlabs.glasskube.eu-v1.yml
Note: Generating CRD keycloaks.glasskube.eu:
Note:   - v1beta1 -> /home/jrab66/Documents/github/millicom/glasskube-operator/operator/build/tmp/kapt3/classes/main/META-INF/fabric8/keycloaks.glasskube.eu-v1beta1.yml
Note:   - v1 -> /home/jrab66/Documents/github/millicom/glasskube-operator/operator/build/tmp/kapt3/classes/main/META-INF/fabric8/keycloaks.glasskube.eu-v1.yml
Note: Generating CRD scheduledbackups.postgresql.cnpg.io:
Note:   - v1beta1 -> /home/jrab66/Documents/github/millicom/glasskube-operator/operator/build/tmp/kapt3/classes/main/META-INF/fabric8/scheduledbackups.postgresql.cnpg.io-v1beta1.yml
Note:   - v1 -> /home/jrab66/Documents/github/millicom/glasskube-operator/operator/build/tmp/kapt3/classes/main/META-INF/fabric8/scheduledbackups.postgresql.cnpg.io-v1.yml

> Task :operator:compileKotlin
w: file:///home/jrab66/Documents/github/millicom/glasskube-operator/operator/src/main/kotlin/eu/glasskube/operator/apps/matomo/Matomo.kt:63:44 'resourceLabels(String, vararg Pair<String, String>): Map<String, String>' is deprecated. Use Labels.resourceLabels instead to opt in to Kubernetes Recommended Labels.
w: file:///home/jrab66/Documents/github/millicom/glasskube-operator/operator/src/main/kotlin/eu/glasskube/operator/apps/odoo/Odoo.kt:81:13 'resourceLabels(String, vararg Pair<String, String>): Map<String, String>' is deprecated. Use Labels.resourceLabels instead to opt in to Kubernetes Recommended Labels.

> Task :operator:bootBuildImage
Building image 'docker.io/glasskube/operator:latest'

 > Pulling builder image 'docker.io/paketobuildpacks/builder-jammy-base:latest' ..................................................
 > Pulled builder image 'paketobuildpacks/builder-jammy-base@sha256:94593b2ad54362e1256da43631661d3dad936a177609a3d297fc638e87c6ee91'
 > Pulling run image 'docker.io/paketobuildpacks/run-jammy-base:latest' ..................................................
 > Pulled run image 'paketobuildpacks/run-jammy-base@sha256:650a1959aa0d79221cd7afdd77bda0ec4602561dce1a23f91cc594d9c8388482'
 > Executing lifecycle version v0.18.5
 > Using build cache volume 'pack-cache-98a3be2253a0.build'

 > Running creator
    [creator]     ===> ANALYZING
    [creator]     Restoring data for SBOM from previous image
    [creator]     ===> DETECTING
    [creator]     6 of 26 buildpacks participating
    [creator]     paketo-buildpacks/ca-certificates   3.6.7
    [creator]     paketo-buildpacks/bellsoft-liberica 10.5.2
    [creator]     paketo-buildpacks/syft              1.44.0
    [creator]     paketo-buildpacks/executable-jar    6.8.3
    [creator]     paketo-buildpacks/dist-zip          5.6.8
    [creator]     paketo-buildpacks/spring-boot       5.27.8
    [creator]     ===> RESTORING
    [creator]     Restoring metadata for "paketo-buildpacks/ca-certificates:helper" from app image
    [creator]     Restoring metadata for "paketo-buildpacks/bellsoft-liberica:helper" from app image
    [creator]     Restoring metadata for "paketo-buildpacks/bellsoft-liberica:java-security-properties" from app image
    [creator]     Restoring metadata for "paketo-buildpacks/bellsoft-liberica:jre" from app image
    [creator]     Restoring metadata for "paketo-buildpacks/syft:syft" from cache
    [creator]     Restoring metadata for "paketo-buildpacks/spring-boot:web-application-type" from app image
    [creator]     Restoring data for "paketo-buildpacks/syft:syft" from cache
    [creator]     Restoring data for SBOM from cache
    [creator]     ===> BUILDING
    [creator]     
    [creator]     Paketo Buildpack for CA Certificates 3.6.7
    [creator]       https://github.com/paketo-buildpacks/ca-certificates
    [creator]       Launch Helper: Reusing cached layer
    [creator]     
    [creator]     Paketo Buildpack for BellSoft Liberica 10.5.2
    [creator]       https://github.com/paketo-buildpacks/bellsoft-liberica
    [creator]       Build Configuration:
    [creator]         $BP_JVM_JLINK_ARGS           --no-man-pages --no-header-files --strip-debug --compress=1  configure custom link arguments (--output must be omitted)
    [creator]         $BP_JVM_JLINK_ENABLED        false                                                        enables running jlink tool to generate custom JRE
    [creator]         $BP_JVM_TYPE                 JRE                                                          the JVM type - JDK or JRE
    [creator]         $BP_JVM_VERSION              17                                                           the Java version
    [creator]       Launch Configuration:
    [creator]         $BPL_DEBUG_ENABLED           false                                                        enables Java remote debugging support
    [creator]         $BPL_DEBUG_PORT              8000                                                         configure the remote debugging port
    [creator]         $BPL_DEBUG_SUSPEND           false                                                        configure whether to suspend execution until a debugger has attached
    [creator]         $BPL_HEAP_DUMP_PATH                                                                       write heap dumps on error to this path
    [creator]         $BPL_JAVA_NMT_ENABLED        true                                                         enables Java Native Memory Tracking (NMT)
    [creator]         $BPL_JAVA_NMT_LEVEL          summary                                                      configure level of NMT, summary or detail
    [creator]         $BPL_JFR_ARGS                                                                             configure custom Java Flight Recording (JFR) arguments
    [creator]         $BPL_JFR_ENABLED             false                                                        enables Java Flight Recording (JFR)
    [creator]         $BPL_JMX_ENABLED             false                                                        enables Java Management Extensions (JMX)
    [creator]         $BPL_JMX_PORT                5000                                                         configure the JMX port
    [creator]         $BPL_JVM_HEAD_ROOM           0                                                            the headroom in memory calculation
    [creator]         $BPL_JVM_LOADED_CLASS_COUNT  35% of classes                                               the number of loaded classes in memory calculation
    [creator]         $BPL_JVM_THREAD_COUNT        250                                                          the number of threads in memory calculation
    [creator]         $JAVA_TOOL_OPTIONS                                                                        the JVM launch flags
    [creator]         Using Java version 17 from BP_JVM_VERSION
    [creator]       BellSoft Liberica JRE 17.0.10: Reusing cached layer
    [creator]       Launch Helper: Reusing cached layer
    [creator]       Java Security Properties: Reusing cached layer
    [creator]     
    [creator]     Paketo Buildpack for Syft 1.44.0
    [creator]       https://github.com/paketo-buildpacks/syft
    [creator]         Downloading from https://github.com/anchore/syft/releases/download/v0.104.0/syft_0.104.0_linux_amd64.tar.gz
    [creator]         Verifying checksum
    [creator]         Writing env.build/SYFT_CHECK_FOR_APP_UPDATE.default
    [creator]     
    [creator]     Paketo Buildpack for Executable JAR 6.8.3
    [creator]       https://github.com/paketo-buildpacks/executable-jar
    [creator]       Command "packages" is deprecated, use `syft scan` instead
    [creator]       Class Path: Contributing to layer
    [creator]         Writing env/CLASSPATH.delim
    [creator]         Writing env/CLASSPATH.prepend
    [creator]       Process types:
    [creator]         executable-jar: java org.springframework.boot.loader.launch.JarLauncher (direct)
    [creator]         task:           java org.springframework.boot.loader.launch.JarLauncher (direct)
    [creator]         web:            java org.springframework.boot.loader.launch.JarLauncher (direct)
    [creator]     
    [creator]     Paketo Buildpack for Spring Boot 5.27.8
    [creator]       https://github.com/paketo-buildpacks/spring-boot
    [creator]       Build Configuration:
    [creator]         $BP_SPRING_CLOUD_BINDINGS_DISABLED   true   whether to contribute Spring Boot cloud bindings support
    [creator]         $BP_SPRING_CLOUD_BINDINGS_VERSION    1      default version of Spring Cloud Bindings library to contribute
    [creator]       Launch Configuration:
    [creator]         $BPL_SPRING_CLOUD_BINDINGS_DISABLED  false  whether to auto-configure Spring Boot environment properties from bindings
    [creator]         $BPL_SPRING_CLOUD_BINDINGS_ENABLED   true   Deprecated - whether to auto-configure Spring Boot environment properties from bindings
    [creator]       Creating slices from layers index
    [creator]         dependencies (54.2 MB)
    [creator]         spring-boot-loader (382.9 KB)
    [creator]         snapshot-dependencies (0.0 B)
    [creator]         application (3.6 MB)
    [creator]       Web Application Type: Contributing to layer
    [creator]         Non-web application detected
    [creator]         Writing env.launch/BPL_JVM_THREAD_COUNT.default
    [creator]       4 application slices
    [creator]       Image labels:
    [creator]         org.opencontainers.image.title
    [creator]         org.opencontainers.image.version
    [creator]         org.springframework.boot.version
    [creator]     Warning: BOM table is deprecated in this buildpack api version, though it remains supported for backwards compatibility. Buildpack authors should write BOM information to <layer>.sbom.<ext>, launch.sbom.<ext>, or build.sbom.<ext>.
    [creator]     ===> EXPORTING
    [creator]     Reusing layer 'paketo-buildpacks/ca-certificates:helper'
    [creator]     Reusing layer 'paketo-buildpacks/bellsoft-liberica:helper'
    [creator]     Reusing layer 'paketo-buildpacks/bellsoft-liberica:java-security-properties'
    [creator]     Reusing layer 'paketo-buildpacks/bellsoft-liberica:jre'
    [creator]     Reusing layer 'paketo-buildpacks/executable-jar:classpath'
    [creator]     Reusing layer 'paketo-buildpacks/spring-boot:web-application-type'
    [creator]     Reusing layer 'buildpacksio/lifecycle:launch.sbom'
    [creator]     Reusing 4/5 app layer(s)
    [creator]     Adding 1/5 app layer(s)
    [creator]     Reusing layer 'buildpacksio/lifecycle:launcher'
    [creator]     Reusing layer 'buildpacksio/lifecycle:config'
    [creator]     Reusing layer 'buildpacksio/lifecycle:process-types'
    [creator]     Adding label 'io.buildpacks.lifecycle.metadata'
    [creator]     Adding label 'io.buildpacks.build.metadata'
    [creator]     Adding label 'io.buildpacks.project.metadata'
    [creator]     Adding label 'org.opencontainers.image.title'
    [creator]     Adding label 'org.opencontainers.image.version'
    [creator]     Adding label 'org.springframework.boot.version'
    [creator]     Setting default process type 'web'
    [creator]     Saving docker.io/glasskube/operator:latest...
    [creator]     *** Images (e6fa2cfdbd88):
    [creator]           docker.io/glasskube/operator:latest
    [creator]     Reusing cache layer 'paketo-buildpacks/syft:syft'
    [creator]     Reusing cache layer 'buildpacksio/lifecycle:cache.sbom'

Successfully built image 'docker.io/glasskube/operator:latest'

Successfully created image tag 'docker.io/glasskube/operator:0.13.14-SNAPSHOT'


Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.5/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 1m 28s
12 actionable tasks: 12 executed

```


I installing  the operator to minikube with: 


I override to latest or the tag that is pushed to minikube
values-reference: 
```
operator:
  image:
    repository: glasskube/operator
    tag: "latest" #"0.13.14-SNAPSHOT"  # defaults to Chart.appVersion if unspecified
  replicaCount: 1
```


install 
```
helm upgrade --install my-glasskube-operator glasskube/glasskube-operator -f glasskube-operator/values-reference.yaml 
Release "my-glasskube-operator" has been upgraded. Happy Helming!
NAME: my-glasskube-operator
LAST DEPLOYED: Fri Feb 23 12:18:13 2024
NAMESPACE: default
STATUS: deployed
REVISION: 3
TEST SUITE: None

```



But seems operator fails to run:

Prior to change image was not complaining over `velero` resources?


```
2024-02-23T18:37:41.541Z [InformerWrapper [miniobuckets.glasskube.eu/v1alpha1] 40] WARN  i.f.k.c.d.i.VersionUsageUtils - The client is using resource type 'miniobuckets' with unstable version 'v1alpha1'                                 │
│ 2024-02-23T18:37:41.542Z [InformerWrapper [planes.glasskube.eu/v1alpha1] 49] WARN  i.f.k.c.d.i.VersionUsageUtils - The client is using resource type 'planes' with unstable version 'v1alpha1'                                             │
│ 2024-02-23T18:37:41.543Z [InformerWrapper [glitchtips.glasskube.eu/v1alpha1] 51] WARN  i.f.k.c.d.i.VersionUsageUtils - The client is using resource type 'glitchtips' with unstable version 'v1alpha1'                                     │
│     at java.base/java.util.concurrent.CompletableFuture.complete(Unknown Source)                                                                                                                                                           │
│     at io.fabric8.kubernetes.client.okhttp.OkHttpClientImpl$OkHttpAsyncBody.doConsume(OkHttpClientImpl.java:137)                                                                                                                           │
│     at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)                                                                                                                                                         │
│     at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)                                                                                                                                                        │
│     at java.base/java.lang.Thread.run(Unknown Source)                                                                                                                                                                                      │
│ Caused by: io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: GET at: https://10.96.0.1:443/apis/velero.io/v1/schedules?labelSelector=app.kubernetes.io%2Fmanaged-by%3Dglasskube-operator%2Capp.kubernetes.io%2Fpa │
│     at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.requestFailure(OperationSupport.java:660)                                                                                                                                │
│     at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.requestFailure(OperationSupport.java:640)                                                                                                                                │
│     at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.assertResponseCode(OperationSupport.java:589)                                                                                                                            │
│     at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.lambda$handleResponse$0(OperationSupport.java:549)                                                                                                                       │
│     ... 17 common frames omitted                                                                                                                                                                                                           │
│ 2024-02-23T18:37:42.737Z [OkHttp Dispatcher] ERROR i.f.k.c.i.i.c.Reflector - listSyncAndWatch failed for velero.io/v1/backupstoragelocations, will stop                                                                                    │
│ java.util.concurrent.CompletionException: io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: GET at: https://10.96.0.1:443/apis/velero.io/v1/backupstoragelocations?labelSelector=app.kubernetes.io%2Fmanaged-by%3 │
│     at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(Unknown Source)                                                                                                                                                    │
│     at java.base/java.util.concurrent.CompletableFuture.completeThrowable(Unknown Source)                                                                                                                                                  │
│     at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(Unknown Source)             

```
