### PR TITLE
fix(nextcloud): set maintenance window and disable logreader

### DIFF
--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/nextcloud/dependent/NextcloudConfigMap.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/nextcloud/dependent/NextcloudConfigMap.kt
@@ -54,6 +54,7 @@ class NextcloudConfigMap : CRUDKubernetesDependentResource<ConfigMap, Nextcloud>
         context.client.kubernetesSerialization.asJson(
             NextcloudInstallConfig(
                 listOfNotNull(
+                    "maintenance_window_start" to 1,
                     primary.spec.defaultPhoneRegion?.let { "default_phone_region" to it },
                     "overwriteprotocol" to "https",
                     "trusted_proxies" to listOf(

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/nextcloud/dependent/NextcloudDeployment.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/nextcloud/dependent/NextcloudDeployment.kt
@@ -114,6 +114,7 @@ class NextcloudDeployment(private val configService: ConfigService) :
                             args = listOf(
                                 "-c",
                                 listOf(
+                                    "php $OCC_PATH app:disable logreader",
                                     "php $OCC_PATH app:install richdocuments",
                                     "php $OCC_PATH app:install contacts",
                                     "php $OCC_PATH app:install calendar",


### PR DESCRIPTION
## Pull Request Template

### Description

* Disable the logreader app to avoid the log iterator error.
* set the maintenance window such that maintenance tasks are done during night.

### Related Issues

- Related to #562 

### Screenshots (if applicable)

Please provide screenshots or GIFs that demonstrate the changes if your pull request includes visual updates.

### Checklist

- [ ] I have read and followed the [contributing guidelines](CONTRIBUTING.md) for this repository.
- [ ] My code follows the coding style and standards of this project.
- [ ] I have tested my changes locally.
- [ ] I have added or updated necessary documentation (if applicable).
- [ ] All new and existing tests passed.
- [ ] My changes have been reviewed by at least one other contributor.
- [ ] I have updated the README or relevant documentation (if applicable).
- [ ] I have added proper labels to this PR (e.g., bug, enhancement, documentation, etc.).

### Additional Information

Please provide any additional information that may be helpful in understanding or reviewing this PR.

