### PR TITLE
fix(matomo): add simple heuristic to choose smtp encryption mode

### DIFF
--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/matomo/dependent/MatomoConfigSecret.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/matomo/dependent/MatomoConfigSecret.kt
@@ -63,7 +63,15 @@ class MatomoConfigSecret(private val objectMapper: ObjectMapper) :
                         "type" to "LOGIN",
                         "username" to authSecret.data.getValue("username").decodeBase64(),
                         "password" to authSecret.data.getValue("password").decodeBase64(),
-                        "encryption" to if (smtp.tlsEnabled) "tls" else ""
+                        "encryption" to
+                            when (smtp.tlsEnabled) {
+                                true -> when (smtp.port) {
+                                    465, 2465 -> "ssl"
+                                    else -> "tls"
+                                }
+
+                                false -> ""
+                            }
                     )
                 }
             }


### PR DESCRIPTION
SMTP port 465 is typically used with SSL/TLS, not STARTTLS. In this case Matomo must be configured with encryption mode SSL rather than TLS. 

With this PR, the operator implicitly assumes that SSL should be used if the port is 465 or 2465 has been specified. 

This is a bit of a hack, but I think it should work for most cases and at least it doesn't bring a breaking change.