### PR TITLE
fix(Gitea): add support for v1.26 and v1.27 

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,6 @@
 [tools]
 java = "17"
+
+[env]
+MINIO_HOST_NAME="localhost"
+MINIO_SECRET_NAME="glasskube-minio"

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/gitea/dependent/GiteaDeployment.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/gitea/dependent/GiteaDeployment.kt
@@ -125,7 +125,10 @@ class GiteaDeployment(private val configService: ConfigService) :
                             name = "environment-to-ini"
                             image = primary.image
                             command = listOf("/bin/sh")
-                            args = listOf("-c", "mkdir -p /data/gitea/conf && rm -f /data/gitea/conf/app.ini && environment-to-ini")
+                            args = listOf(
+                                "-c",
+                                "mkdir -p $CONF_DIR && rm -f $APP_INI && environment-to-ini --config $APP_INI"
+                            )
                             volumeMounts {
                                 volumeMount {
                                     name = VOLUME_NAME
@@ -222,5 +225,10 @@ class GiteaDeployment(private val configService: ConfigService) :
     companion object {
         private const val VOLUME_NAME = "data"
         internal const val WORK_DIR = "/data"
+
+        // Since Gitea 1.26 "environment-to-ini" wraps "gitea config edit-ini",
+        // which requires an explicit --config instead of guessing the path.
+        private const val CONF_DIR = "$WORK_DIR/gitea/conf"
+        private const val APP_INI = "$CONF_DIR/app.ini"
     }
 }

--- a/operator/src/main/kotlin/eu/glasskube/operator/apps/gitea/dependent/GiteaIniConfigMap.kt
+++ b/operator/src/main/kotlin/eu/glasskube/operator/apps/gitea/dependent/GiteaIniConfigMap.kt
@@ -55,9 +55,24 @@ class GiteaIniConfigMap : CRUDKubernetesDependentResource<ConfigMap, Gitea>(Conf
             "GITEA__cache__HOST" to "redis://$redisName:6379/0?pool_size=100&idle_timeout=180s",
             "GITEA__queue__TYPE" to "redis",
             "GITEA__queue__CONN_STR" to "redis://$redisName:6379/0?pool_size=100&idle_timeout=180s",
-            "GITEA__metrics__ENABLED" to "true",
-            "GITEA__webhook__ALLOWED_HOST_LIST" to "*"
-        )
+            "GITEA__metrics__ENABLED" to "true"
+        ) + allowedHostListConfig
+
+    // Gitea 1.27 deprecated "[webhook] ALLOWED_HOST_LIST" in favour of "[security] ALLOWED_HOST_LIST",
+    // which does not exist in earlier versions. Webhook delivery falls back to the security option
+    // when the webhook one is unset, so both variants allow webhooks to call any host.
+    private val Gitea.allowedHostListConfig
+        get() = when {
+            isVersionAtLeast(1, 27) -> mapOf("GITEA__security__ALLOWED_HOST_LIST" to "*")
+            else -> mapOf("GITEA__webhook__ALLOWED_HOST_LIST" to "*")
+        }
+
+    private fun Gitea.isVersionAtLeast(major: Int, minor: Int): Boolean {
+        val parts = spec.version.split('.')
+        val actualMajor = parts.getOrNull(0)?.toIntOrNull() ?: return false
+        val actualMinor = parts.getOrNull(1)?.toIntOrNull() ?: return false
+        return actualMajor > major || (actualMajor == major && actualMinor >= minor)
+    }
 
     private fun getSmtpConfig(primary: Gitea, context: Context<Gitea>): Map<String, String> =
         when (val smtp = primary.spec.smtp) {


### PR DESCRIPTION
v1.26 requires a change in how `environment-to-ini` is called

v1.27 deprecated `GITEA__webhook__ALLOWED_HOST_LIST`

also added some base development env vars to the mise.toml file